### PR TITLE
changing the vernacular of 'errors' to 'results'

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -73,12 +73,12 @@ module.exports = function (program) {
     lesshint.configure(config);
 
     promises = program.args.map(lesshint.checkPath, lesshint);
-    Vow.all(promises).then(function (errors) {
+    Vow.all(promises).then(function (results) {
         var reporter;
 
-        errors = [].concat.apply([], errors);
+        results = [].concat.apply([], results);
 
-        if (!errors.length) {
+        if (!results.length) {
             exitDefer.resolve(EXIT_CODES.OK);
 
             return;
@@ -87,7 +87,7 @@ module.exports = function (program) {
         reporter = getReporter(program.reporter);
 
         if (reporter) {
-            reporter(errors);
+            reporter(results);
         } else {
             console.error('Could not find reporter "%s".', program.reporter);
         }

--- a/lib/lesshint.js
+++ b/lib/lesshint.js
@@ -36,8 +36,8 @@ Lesshint.prototype.checkDirectory = function (checkPath) {
             }, this);
         }, this);
 
-        return Vow.all(files).then(function (errors) {
-            return [].concat.apply([], errors);
+        return Vow.all(files).then(function (results) {
+            return [].concat.apply([], results);
         });
     }, this);
 };

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -38,29 +38,29 @@ var linters = [
     require('./linters/zero_unit')
 ];
 
-var processErrors = function (errors, input, fullPath) {
+var processResults = function (results, input, fullPath) {
     var filename = path.basename(fullPath);
     var lines = input.split('\n');
 
-    errors = errors.filter(function (error) {
-        return error !== null;
+    results = results.filter(function (result) {
+        return result !== null;
     });
 
-    errors = flatten(errors);
-    errors = errors.map(function (error) {
-        var line = error.line;
+    results = flatten(results);
+    results = results.map(function (result) {
+        var line = result.line;
 
-        error.file = filename;
-        error.source = line ? lines[line - 1] : '';
+        result.file = filename;
+        result.source = line ? lines[line - 1] : '';
 
-        return error;
+        return result;
     });
 
-    return errors;
+    return results;
 };
 
 exports.lint = function (input, fullPath, config) {
-    var errors = [];
+    var results = [];
     var ast;
 
     input = input.replace(/\r\n|\r|\n/g, '\n'); // Normalize line endings. See #40
@@ -73,14 +73,14 @@ exports.lint = function (input, fullPath, config) {
         var i;
 
         for (i = 0; i < linters.length; i++) {
-            errors.push(linters[i].call(null, {
+            results.push(linters[i].call(null, {
                 config: config,
                 node: node
             }));
         }
     });
 
-    return processErrors(errors, input, fullPath);
+    return processResults(results, input, fullPath);
 };
 
 exports.parseAST = function (input) {

--- a/lib/linters/duplicate_property.js
+++ b/lib/linters/duplicate_property.js
@@ -5,7 +5,7 @@ module.exports = function (options) {
     var node = options.node;
     var properties = [];
     var excludes = [];
-    var errors = [];
+    var results = [];
 
     // Bail if the linter isn't wanted
     if (!config.duplicateProperty || (config.duplicateProperty && !config.duplicateProperty.enabled)) {
@@ -23,7 +23,7 @@ module.exports = function (options) {
         var property = declaration.first('property').content[0];
 
         if ((property && property.type === 'ident') && properties.indexOf(property.content) !== -1) {
-            errors.push({
+            results.push({
                 message: 'Duplicate property: "' + property.content + '".',
                 column: property.start.column,
                 line: property.start.line
@@ -35,13 +35,13 @@ module.exports = function (options) {
         }
     });
 
-    if (errors.length) {
-        return errors.map(function (error) {
+    if (results.length) {
+        return results.map(function (result) {
             return {
-                column: error.column,
-                line: error.line,
+                column: result.column,
+                line: result.line,
                 linter: 'duplicateProperty',
-                message: error.message
+                message: result.message
             };
         });
     }

--- a/lib/linters/import_path.js
+++ b/lib/linters/import_path.js
@@ -6,7 +6,7 @@ module.exports = function (options) {
     var filename = path.basename(options.path);
     var config = options.config;
     var node = options.node;
-    var errors = [];
+    var results = [];
     var excludes;
     var value;
     var file;
@@ -37,7 +37,7 @@ module.exports = function (options) {
     switch (config.importPath.filenameExtension) {
         case false:
             if (path.extname(file)) {
-                errors.push({
+                results.push({
                     column: value.start.column,
                     line: value.start.line,
                     message: 'Imported file, "' + file + '" should not include the file extension.'
@@ -47,7 +47,7 @@ module.exports = function (options) {
             break;
         case true:
             if (!path.extname(file)) {
-                errors.push({
+                results.push({
                     column: value.start.column,
                     line: value.start.line,
                     message: 'Imported file, "' + file + '" should include the file extension.'
@@ -61,7 +61,7 @@ module.exports = function (options) {
     switch (config.importPath.leadingUnderscore) {
         case false:
             if (/^_/.test(file)) {
-                errors.push({
+                results.push({
                     column: value.start.column,
                     line: value.start.line,
                     message: 'Imported file, "' + file + '" should not include a leading underscore.'
@@ -71,7 +71,7 @@ module.exports = function (options) {
             break;
         case true:
             if (!/^_/.test(file)) {
-                errors.push({
+                results.push({
                     column: value.start.column,
                     line: value.start.line,
                     message: 'Imported file, "' + file + '" should include a leading underscore.'
@@ -81,13 +81,13 @@ module.exports = function (options) {
             break;
     }
 
-    if (errors.length) {
-        return errors.map(function (error) {
+    if (results.length) {
+        return results.map(function (result) {
             return {
-                column: error.column,
-                line: error.line,
+                column: result.column,
+                line: result.line,
                 linter: 'importPath',
-                message: error.message
+                message: result.message
             };
         });
     }

--- a/lib/linters/property_units.js
+++ b/lib/linters/property_units.js
@@ -3,7 +3,7 @@
 module.exports = function (options) {
     var config = options.config;
     var node = options.node;
-    var errors = [];
+    var results = [];
     var property;
     var value;
 
@@ -34,7 +34,7 @@ module.exports = function (options) {
             return;
         }
 
-        errors.push({
+        results.push({
             column: element.start.column,
             line: element.start.line,
             message: 'Unit "' + unit + '" is not allowed for "' + property + '".'
@@ -51,7 +51,7 @@ module.exports = function (options) {
                 }
             }
 
-            errors.push({
+            results.push({
                 column: element.start.column,
                 line: element.start.line,
                 message: 'Percentages are not allowed for "' + property + '".'
@@ -59,13 +59,13 @@ module.exports = function (options) {
         });
     }
 
-    if (errors.length) {
-        return errors.map(function (error) {
+    if (results.length) {
+        return results.map(function (result) {
             return {
-                column: error.column,
-                line: error.line,
+                column: result.column,
+                line: result.line,
                 linter: 'propertyUnits',
-                message: error.message
+                message: result.message
             };
         });
     }

--- a/lib/linters/qualifying_element.js
+++ b/lib/linters/qualifying_element.js
@@ -3,7 +3,7 @@
 module.exports = function (options) {
     var config = options.config;
     var node = options.node;
-    var error = {};
+    var result = {};
 
     // Bail if the linter isn't wanted
     if (!config.qualifyingElement || (config.qualifyingElement && !config.qualifyingElement.enabled)) {
@@ -26,7 +26,7 @@ module.exports = function (options) {
                     return;
                 }
 
-                error = {
+                result = {
                     message: 'Attribute selectors should not include a qualifying element.',
                     column: selector.start.column,
                     line: selector.start.line
@@ -38,7 +38,7 @@ module.exports = function (options) {
                     return;
                 }
 
-                error = {
+                result = {
                     message: 'Class selectors should not include a qualifying element.',
                     column: selector.start.column,
                     line: selector.start.line
@@ -50,7 +50,7 @@ module.exports = function (options) {
                     return;
                 }
 
-                error = {
+                result = {
                     message: 'ID selectors should not include a qualifying element.',
                     column: selector.start.column,
                     line: selector.start.line
@@ -60,12 +60,12 @@ module.exports = function (options) {
         }
     });
 
-    if (error.message) {
+    if (result.message) {
         return {
-            column: error.column,
-            line: error.line,
+            column: result.column,
+            line: result.line,
             linter: 'qualifyingElement',
-            message: error.message
+            message: result.message
         };
     }
 

--- a/lib/linters/single_line_per_property.js
+++ b/lib/linters/single_line_per_property.js
@@ -3,7 +3,7 @@
 module.exports = function (options) {
     var config = options.config;
     var node = options.node;
-    var errors = [];
+    var results = [];
 
     // Bail if the linter isn't wanted
     if (!config.singleLinePerProperty || (config.singleLinePerProperty && !config.singleLinePerProperty.enabled)) {
@@ -21,7 +21,7 @@ module.exports = function (options) {
 
         // If no sibling nodes were found, assume there's no new line
         if ((!prev || !next) || (prev.content.indexOf('\n') === -1 || next.content.indexOf('\n') === -1)) {
-            errors.push({
+            results.push({
                 column: element.start.column,
                 line: element.start.line,
                 message: "Each property should be on it's own line."
@@ -29,13 +29,13 @@ module.exports = function (options) {
         }
     });
 
-    if (errors.length) {
-        return errors.map(function (error) {
+    if (results.length) {
+        return results.map(function (result) {
             return {
-                column: error.column,
-                line: error.line,
+                column: result.column,
+                line: result.line,
                 linter: 'singleLinePerProperty',
-                message: error.message
+                message: result.message
             };
         });
     }

--- a/lib/linters/single_line_per_selector.js
+++ b/lib/linters/single_line_per_selector.js
@@ -3,7 +3,7 @@
 module.exports = function (options) {
     var config = options.config;
     var node = options.node;
-    var errors = [];
+    var results = [];
 
     // Bail if the linter isn't wanted
     if (!config.singleLinePerSelector || (config.singleLinePerSelector && !config.singleLinePerSelector.enabled)) {
@@ -25,7 +25,7 @@ module.exports = function (options) {
         }
 
         if (element.get(0).content.indexOf('\n') === -1) {
-            errors.push({
+            results.push({
                 column: element.start.column,
                 line: element.start.line,
                 message: "Each selector should be on it's own line."
@@ -33,13 +33,13 @@ module.exports = function (options) {
         }
     });
 
-    if (errors.length) {
-        return errors.map(function (error) {
+    if (results.length) {
+        return results.map(function (result) {
             return {
-                column: error.column,
-                line: error.line,
+                column: result.column,
+                line: result.line,
                 linter: 'singleLinePerSelector',
-                message: error.message
+                message: result.message
             };
         });
     }

--- a/lib/linters/space_after_comma.js
+++ b/lib/linters/space_after_comma.js
@@ -3,7 +3,7 @@
 module.exports = function (options) {
     var config = options.config;
     var node = options.node;
-    var errors = [];
+    var results = [];
 
     // Bail if the linter isn't wanted
     if (!config.spaceAfterComma || (config.spaceAfterComma && !config.spaceAfterComma.enabled)) {
@@ -24,7 +24,7 @@ module.exports = function (options) {
         switch (config.spaceAfterComma.style) {
             case 'no_space':
                 if (element.type === 'space') {
-                    errors.push({
+                    results.push({
                         column: start.column,
                         line: start.line,
                         message: 'Commas should not be followed by any space.'
@@ -34,7 +34,7 @@ module.exports = function (options) {
                 break;
             case 'one_space':
                 if (element.type !== 'space' || element.content !== ' ') {
-                    errors.push({
+                    results.push({
                         column: start.column,
                         line: start.line,
                         message: 'Commas should be followed by one space.'
@@ -49,13 +49,13 @@ module.exports = function (options) {
         }
     });
 
-    if (errors.length) {
-        return errors.map(function (error) {
+    if (results.length) {
+        return results.map(function (result) {
             return {
-                column: error.column,
-                line: error.line,
+                column: result.column,
+                line: result.line,
                 linter: 'spaceAfterComma',
-                message: error.message
+                message: result.message
             };
         });
     }

--- a/lib/linters/space_after_property_value.js
+++ b/lib/linters/space_after_property_value.js
@@ -3,7 +3,7 @@
 module.exports = function (options) {
     var config = options.config;
     var node = options.node;
-    var errors = [];
+    var results = [];
 
     // Bail if the linter isn't wanted
     if (!config.spaceAfterPropertyValue || (config.spaceAfterPropertyValue && !config.spaceAfterPropertyValue.enabled)) {
@@ -21,7 +21,7 @@ module.exports = function (options) {
         switch (config.spaceAfterPropertyValue.style) {
             case 'no_space':
                 if (maybeSpace.type === 'space') {
-                    errors.push({
+                    results.push({
                         column: maybeSpace.start.column,
                         line: maybeSpace.start.line,
                         message: 'Semicolon after property value should not be preceded by any space.'
@@ -31,7 +31,7 @@ module.exports = function (options) {
                 break;
             case 'one_space':
                 if (maybeSpace.type !== 'space' || (maybeSpace.type === 'space' && maybeSpace.content !== ' ')) {
-                    errors.push({
+                    results.push({
                         column: maybeSpace.start.column,
                         line: maybeSpace.start.line,
                         message: 'Semicolon after property value should be preceded by one space.'
@@ -46,13 +46,13 @@ module.exports = function (options) {
         }
     });
 
-    if (errors.length) {
-        return errors.map(function (error) {
+    if (results.length) {
+        return results.map(function (result) {
             return {
-                column: error.column,
-                line: error.line,
+                column: result.column,
+                line: result.line,
                 linter: 'spaceAfterPropertyValue',
-                message: error.message
+                message: result.message
             };
         });
     }

--- a/lib/linters/space_before_comma.js
+++ b/lib/linters/space_before_comma.js
@@ -3,7 +3,7 @@
 module.exports = function (options) {
     var config = options.config;
     var node = options.node;
-    var errors = [];
+    var results = [];
 
     // Bail if the linter isn't wanted
     if (!config.spaceBeforeComma || (config.spaceBeforeComma && !config.spaceBeforeComma.enabled)) {
@@ -24,7 +24,7 @@ module.exports = function (options) {
         switch (config.spaceBeforeComma.style) {
             case 'no_space':
                 if (element.type === 'space') {
-                    errors.push({
+                    results.push({
                         column: start.column,
                         line: start.line,
                         message: 'Commas should not be preceded by any space.'
@@ -34,7 +34,7 @@ module.exports = function (options) {
                 break;
             case 'one_space':
                 if (element.type !== 'space' || element.content !== ' ') {
-                    errors.push({
+                    results.push({
                         column: start.column,
                         line: start.line,
                         message: 'Commas should be preceded by one space.'
@@ -49,13 +49,13 @@ module.exports = function (options) {
         }
     });
 
-    if (errors.length) {
-        return errors.map(function (error) {
+    if (results.length) {
+        return results.map(function (result) {
             return {
-                column: error.column,
-                line: error.line,
+                column: result.column,
+                line: result.line,
                 linter: 'spaceBeforeComma',
-                message: error.message
+                message: result.message
             };
         });
     }

--- a/lib/linters/space_between_parens.js
+++ b/lib/linters/space_between_parens.js
@@ -3,7 +3,7 @@
 module.exports = function (options) {
     var config = options.config;
     var node = options.node;
-    var errors = [];
+    var results = [];
     var first;
     var last;
 
@@ -23,7 +23,7 @@ module.exports = function (options) {
     switch (config.spaceBetweenParens.style) {
         case 'no_space':
             if (first && first.type === 'space') {
-                errors.push({
+                results.push({
                     column: first.start.column,
                     line: first.start.line,
                     message: 'Opening parenthesis should not be followed by any space.'
@@ -31,7 +31,7 @@ module.exports = function (options) {
             }
 
             if (last && last.type === 'space') {
-                errors.push({
+                results.push({
                     column: last.start.column,
                     line: last.start.line,
                     message: 'Closing parenthesis should not be preceded by any space.'
@@ -41,7 +41,7 @@ module.exports = function (options) {
             break;
         case 'one_space':
             if (first && (first.type !== 'space' || first.content !== ' ')) {
-                errors.push({
+                results.push({
                     column: first.start.column,
                     line: first.start.line,
                     message: 'Opening parenthesis should be followed by one space.'
@@ -49,7 +49,7 @@ module.exports = function (options) {
             }
 
             if (last && (last.type !== 'space' || last.content !== ' ')) {
-                errors.push({
+                results.push({
                     column: last.start.column,
                     line: last.start.line,
                     message: 'Closing parenthesis should be preceded by one space.'
@@ -63,13 +63,13 @@ module.exports = function (options) {
             );
     }
 
-    if (errors.length) {
-        return errors.map(function (error) {
+    if (results.length) {
+        return results.map(function (result) {
             return {
-                column: error.column,
-                line: error.line,
+                column: result.column,
+                line: result.line,
                 linter: 'spaceBetweenParens',
-                message: error.message
+                message: result.message
             };
         });
     }

--- a/lib/linters/string_quotes.js
+++ b/lib/linters/string_quotes.js
@@ -3,7 +3,7 @@
 module.exports = function (options) {
     var config = options.config;
     var node = options.node;
-    var errors = [];
+    var results = [];
 
     // Bail if the linter isn't wanted
     if (!config.stringQuotes || (config.stringQuotes && !config.stringQuotes.enabled)) {
@@ -23,7 +23,7 @@ module.exports = function (options) {
         switch (config.stringQuotes.style) {
             case 'double':
                 if (!/".*"/.test(element.content)) {
-                    errors.push({
+                    results.push({
                         message: 'Strings should use double quotes.',
                         column: element.start.column,
                         line: element.start.line
@@ -33,7 +33,7 @@ module.exports = function (options) {
                 break;
             case 'single':
                 if (!/'.*'/.test(element.content)) {
-                    errors.push({
+                    results.push({
                         message: 'Strings should use single quotes.',
                         column: element.start.column,
                         line: element.start.line
@@ -48,13 +48,13 @@ module.exports = function (options) {
         }
     });
 
-    if (errors.length) {
-        return errors.map(function (error) {
+    if (results.length) {
+        return results.map(function (result) {
             return {
-                column: error.column,
-                line: error.line,
+                column: result.column,
+                line: result.line,
                 linter: 'stringQuotes',
-                message: error.message
+                message: result.message
             };
         });
     }

--- a/lib/linters/trailing_whitespace.js
+++ b/lib/linters/trailing_whitespace.js
@@ -3,7 +3,7 @@
 module.exports = function (options) {
     var config = options.config;
     var node = options.node;
-    var errors = [];
+    var results = [];
 
     // Bail if the linter isn't wanted
     if (!config.trailingWhitespace || (config.trailingWhitespace && !config.trailingWhitespace.enabled)) {
@@ -19,17 +19,17 @@ module.exports = function (options) {
     node = node.toString('less');
     node.split('\n').forEach(function (line, index) {
         if (/[ \t]+$/g.test(line)) {
-            errors.push({
+            results.push({
                 line: index + 1 // Since index is zero-based
             });
         }
     });
 
-    if (errors.length) {
-        return errors.map(function (error) {
+    if (results.length) {
+        return results.map(function (result) {
             return {
                 column: null,
-                line: error.line,
+                line: result.line,
                 linter: 'trailingWhitespace',
                 message: "There should't be any trailing whitespace."
             };

--- a/lib/reporters/stylish.js
+++ b/lib/reporters/stylish.js
@@ -2,22 +2,22 @@
 
 var chalk = require('chalk');
 
-module.exports = function (errors) {
-    errors.forEach(function (error) {
+module.exports = function (results) {
+    results.forEach(function (result) {
         var output = '';
 
-        output += chalk.cyan(error.file) + ': ';
+        output += chalk.cyan(result.file) + ': ';
 
-        if (error.line) {
-            output += chalk.magenta('line ' + error.line) + ', ';
+        if (result.line) {
+            output += chalk.magenta('line ' + result.line) + ', ';
         }
 
-        if (error.column) {
-            output += chalk.magenta('col ' + error.column) + ', ';
+        if (result.column) {
+            output += chalk.magenta('col ' + result.column) + ', ';
         }
 
-        output += chalk.green(error.linter) + ': ';
-        output += error.message;
+        output += chalk.green(result.linter) + ': ';
+        output += result.message;
 
         console.log(output);
     });


### PR DESCRIPTION
This is in preparation for the separation of warnings from errors, and the addition of errors as a separate result type. Passes `npm test`

