### PR TITLE
Errors vs warnings

### DIFF
--- a/lib/config/defaults.json
+++ b/lib/config/defaults.json
@@ -3,8 +3,6 @@
 
     "excludedFiles": [],
 
-    "mapResults": false,
-
     "attributeQuotes": {
         "enabled": true,
         "style": "single"

--- a/lib/config/defaults.json
+++ b/lib/config/defaults.json
@@ -3,6 +3,8 @@
 
     "excludedFiles": [],
 
+    "mapResults": false,
+
     "attributeQuotes": {
         "enabled": true,
         "style": "single"

--- a/lib/lesshint.js
+++ b/lib/lesshint.js
@@ -60,11 +60,29 @@ Lesshint.prototype.checkPath = function (checkPath) {
 
 Lesshint.prototype.checkString = function (input, checkPath) {
     var result;
+    var matches;
+    var lineNo;
 
     try {
         result = linter.lint(input, checkPath, this.config);
     } catch (e) {
-        result = [];
+
+        matches = e.message.match(/\#(\d+)$/);
+
+        // lineNo should never be 0, but in the event that gonzales-pe
+        // throws a different message, let's account for it. I couldn't
+        // find any instance that this would happen.
+        lineNo = matches.length > 1 ? parseInt(matches[1]) : 0;
+
+        result = [{
+            // errors from gonzales-pe only return line number at the moment,
+            // so we can safely assume column 1, as the entire line is affected.
+            column: 1,
+            line: lineNo,
+            linter: 'gonzales-pe',
+            message: e.message,
+            type: linter.resultTypes.error
+        }];
     }
 
     return result;

--- a/lib/lesshint.js
+++ b/lib/lesshint.js
@@ -78,6 +78,7 @@ Lesshint.prototype.checkString = function (input, checkPath) {
             // errors from gonzales-pe only return line number at the moment,
             // so we can safely assume column 1, as the entire line is affected.
             column: 1,
+            file: path.basename(checkPath),
             line: lineNo,
             linter: 'gonzales-pe',
             message: e.message,

--- a/lib/lesshint.js
+++ b/lib/lesshint.js
@@ -81,7 +81,7 @@ Lesshint.prototype.checkString = function (input, checkPath) {
             line: lineNo,
             linter: 'gonzales-pe',
             message: e.message,
-            type: linter.resultTypes.error
+            severity: linter.resultSeverity.error
         }];
     }
 

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -53,8 +53,8 @@ var processResults = function (results, input, fullPath) {
         result.file = filename;
         result.source = line ? lines[line - 1] : '';
 
-        if (!result.type) {
-            result.type = exports.resultTypes.warning;
+        if (!result.severity) {
+            result.severity = exports.resultSeverity.warning;
         }
 
         return result;
@@ -63,23 +63,9 @@ var processResults = function (results, input, fullPath) {
     return results;
 };
 
-var mapResults = function (results) {
-    var map = {warnings: [], errors: []};
-
-    results.forEach(function (result) {
-        if (result.type === exports.resultTypes.warning) {
-            map.warnings.push(result);
-        } else if (result.type === exports.resultTypes.error) {
-            map.errors.push(result);
-        }
-    });
-
-    return map;
-};
-
-exports.resultTypes = {
-    error: 'ERROR',
-    warning: 'WARNING'
+exports.resultSeverity = {
+    error: 'error',
+    warning: 'warning'
 };
 
 exports.lint = function (input, fullPath, config) {
@@ -103,12 +89,7 @@ exports.lint = function (input, fullPath, config) {
         }
     });
 
-    if (config.mapResults) {
-        results = processResults(results, input, fullPath);
-        return mapResults(results);
-    } else {
-        return processResults(results, input, fullPath);
-    }
+    return processResults(results, input, fullPath);
 };
 
 exports.parseAST = function (input) {

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -53,10 +53,33 @@ var processResults = function (results, input, fullPath) {
         result.file = filename;
         result.source = line ? lines[line - 1] : '';
 
+        if (!result.type) {
+            result.type = exports.resultTypes.warning;
+        }
+
         return result;
     });
 
     return results;
+};
+
+var mapResults = function (results) {
+    var map = {warnings: [], errors: []};
+
+    results.forEach(function (result) {
+        if (result.type === exports.resultTypes.warning) {
+            map.warnings.push(result);
+        } else if (result.type === exports.resultTypes.error) {
+            map.errors.push(result);
+        }
+    });
+
+    return map;
+};
+
+exports.resultTypes = {
+    error: 'ERROR',
+    warning: 'WARNING'
 };
 
 exports.lint = function (input, fullPath, config) {
@@ -80,7 +103,12 @@ exports.lint = function (input, fullPath, config) {
         }
     });
 
-    return processResults(results, input, fullPath);
+    if (config.mapResults) {
+        results = processResults(results, input, fullPath);
+        return mapResults(results);
+    } else {
+        return processResults(results, input, fullPath);
+    }
 };
 
 exports.parseAST = function (input) {

--- a/test/specs/lesshint.js
+++ b/test/specs/lesshint.js
@@ -133,7 +133,7 @@ describe('lesshint', function () {
             results = lesshint.checkString(string);
 
             assert.ok(results.length === 1);
-            assert.ok(results[0].type === 'ERROR');
+            assert.ok(results[0].severity === 'error');
         });
     });
 

--- a/test/specs/lesshint.js
+++ b/test/specs/lesshint.js
@@ -122,17 +122,18 @@ describe('lesshint', function () {
             assert.ok(errors.length === 1);
         });
 
-        it('should return an empty array on invalid input', function () {
+        it('should return an object containing an error result on invalid input', function () {
             var string = '.foo{';
 
             var lesshint = new Lesshint();
-            var errors;
+            var results;
 
             lesshint.configure();
 
-            errors = lesshint.checkString(string);
+            results = lesshint.checkString(string);
 
-            assert.ok(errors.length === 0);
+            assert.ok(results.length === 1);
+            assert.ok(results[0].type === 'ERROR');
         });
     });
 

--- a/test/specs/linter.js
+++ b/test/specs/linter.js
@@ -36,7 +36,8 @@ describe('linter', function () {
                 line: 2,
                 linter: 'spaceAfterPropertyColon',
                 message: 'Colon after property name should be followed by one space.',
-                source: ' margin-right:10px; }'
+                source: ' margin-right:10px; }',
+                type: 'WARNING'
             }];
 
             var config = {
@@ -62,7 +63,8 @@ describe('linter', function () {
                 line: 1,
                 linter: 'spaceBeforeBrace',
                 message: 'Opening curly brace should be preceded by one space.',
-                source: '.foo{ color: red; }'
+                source: '.foo{ color: red; }',
+                type: 'WARNING'
             }];
 
             var config = {
@@ -88,7 +90,8 @@ describe('linter', function () {
                 line: 1,
                 linter: 'spaceBeforeBrace',
                 message: 'Opening curly brace should be preceded by one space.',
-                source: '.foo{}'
+                source: '.foo{}',
+                type: 'WARNING'
             }];
 
             var config = {

--- a/test/specs/linter.js
+++ b/test/specs/linter.js
@@ -37,7 +37,7 @@ describe('linter', function () {
                 linter: 'spaceAfterPropertyColon',
                 message: 'Colon after property name should be followed by one space.',
                 source: ' margin-right:10px; }',
-                type: 'WARNING'
+                severity: 'warning'
             }];
 
             var config = {
@@ -64,7 +64,7 @@ describe('linter', function () {
                 linter: 'spaceBeforeBrace',
                 message: 'Opening curly brace should be preceded by one space.',
                 source: '.foo{ color: red; }',
-                type: 'WARNING'
+                severity: 'warning'
             }];
 
             var config = {
@@ -91,7 +91,7 @@ describe('linter', function () {
                 linter: 'spaceBeforeBrace',
                 message: 'Opening curly brace should be preceded by one space.',
                 source: '.foo{}',
-                type: 'WARNING'
+                severity: 'warning'
             }];
 
             var config = {


### PR DESCRIPTION
In reference to: https://github.com/lesshint/lesshint/issues/44

This is dependant upon https://github.com/lesshint/lesshint/pull/46

Defines warnings vs errors. Since linters aren't inheriting anything from a parent object and are duplicating a lot of code, the code to allow overriding of their result type will have to be pasted manually in each linter. This PR accounts for missing `type` property on each result and adds the default of `linter.resultType.warning` if it's not found.

This can be considered a minor semver change for the fact that it significantly adds to functionality, or a patch change since it contains no breaking changes.