### PR TITLE
fix(attributeQuotes): skip validation for value-less selector

### DIFF
--- a/lib/linters/attribute_quotes.js
+++ b/lib/linters/attribute_quotes.js
@@ -24,6 +24,11 @@ module.exports = function (options) {
         return null;
     }
 
+    // Bail if there's no value to check
+    if (!selector.contains('attributeSelector')) {
+        return null;
+    }
+
     // Use last ident when no quotes are present
     value = selector.first('string') || selector.last('ident');
 

--- a/test/specs/linters/attribute_quotes.js
+++ b/test/specs/linters/attribute_quotes.js
@@ -203,6 +203,24 @@ describe('lesshint', function () {
             }));
         });
 
+        it('should return null for value-less selectors', function () {
+            var source = 'input[disabled] {}';
+            var ast;
+            var options = {
+                attributeQuotes: {
+                    enabled: true
+                }
+            };
+
+            ast = linter.parseAST(source);
+            ast = ast.first().first('selector').first('simpleSelector');
+
+            assert.equal(null, attributeQuotes({
+                config: options,
+                node: ast
+            }));
+        });
+
         it('should throw on invalid "style" value', function () {
             var source = 'input[type=text] {}';
             var ast;


### PR DESCRIPTION
Support value-less attributes (a.k.a. boolean attributes)