### PR TITLE
Better handling and catching of errors.

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -11,6 +11,7 @@ var EXIT_CODES = {
     OK: 0,
     WARNING: 1,
     NOINPUT: 66,
+    SOFTWARE: 70,
     CONFIG: 78
 };
 
@@ -97,6 +98,11 @@ module.exports = function (program) {
         }
 
         exitDefer.reject(EXIT_CODES.WARNING);
+    }).fail(function (error) {
+        console.error('An unkown error occured, please file an issue with this info:');
+        console.error(error.stack);
+
+        exitDefer.reject(EXIT_CODES.SOFTWARE);
     });
 
     return exitPromise;

--- a/lib/lesshint.js
+++ b/lib/lesshint.js
@@ -59,28 +59,41 @@ Lesshint.prototype.checkPath = function (checkPath) {
 };
 
 Lesshint.prototype.checkString = function (input, checkPath) {
-    var result;
+    var lineNo = 0;
     var matches;
-    var lineNo;
+    var result;
 
     try {
         result = linter.lint(input, checkPath, this.config);
     } catch (e) {
+        if (e.name !== 'Parsing error') {
+            /**
+             * Unkown error, i.e. not thrown by gonzales-pe.
+             * Rethrow and let someone else handle it.
+             */
+            throw e;
+        }
 
         matches = e.message.match(/\#(\d+)$/);
 
-        // lineNo should never be 0, but in the event that gonzales-pe
-        // throws a different message, let's account for it. I couldn't
-        // find any instance that this would happen.
-        lineNo = matches.length > 1 ? parseInt(matches[1]) : 0;
+        /**
+         * lineNo should never be 0, but in the event that gonzales-pe
+         * throws a different message, let's account for it. I couldn't
+         * find any instance that this would happen.
+         */
+        if (matches && matches.length > 1) {
+            lineNo = parseInt(matches[1]);
+        }
 
         result = [{
-            // errors from gonzales-pe only return line number at the moment,
-            // so we can safely assume column 1, as the entire line is affected.
+            /**
+             * Errors from gonzales-pe only return line number at the moment,
+             * so we can safely assume column 1, as the entire line is affected.
+             */
             column: 1,
             file: path.basename(checkPath),
             line: lineNo,
-            linter: 'gonzales-pe',
+            linter: 'parse error',
             message: e.message,
             severity: linter.resultSeverity.error
         }];

--- a/test/data/config/bad.json
+++ b/test/data/config/bad.json
@@ -1,0 +1,6 @@
+{
+    "spaceBeforeBrace": {
+        "enabled": true,
+        "style_foobar": "new_line"
+    }
+}

--- a/test/specs/cli.js
+++ b/test/specs/cli.js
@@ -161,4 +161,17 @@ describe('cli', function () {
             assert.ok(status === 1);
         });
     });
+
+    it('should exit with error when a error is thrown', function () {
+        var result;
+
+        result = cli({
+            args: [path.dirname(__dirname) + '/data/files/foo.less'],
+            config: path.dirname(__dirname) + '/data/config/bad.json'
+        });
+
+        return result.fail(function (status) {
+            assert.ok(status === 70);
+        });
+    });
 });

--- a/test/specs/lesshint.js
+++ b/test/specs/lesshint.js
@@ -147,6 +147,15 @@ describe('lesshint', function () {
 
             assert.ok(results[0].file === 'file.less');
         });
+
+        it('should throw on non-parse related errors', function () {
+            var config = configLoader(path.dirname(__dirname) + '/data/config/bad.json');
+            var lesshint = new Lesshint();
+
+            lesshint.configure(config);
+
+            assert.throws(lesshint.checkString.bind(null), Error);
+        });
     });
 
     describe('configure', function () {


### PR DESCRIPTION
As discussed in #62. Lets make sure we don't try to parse all kinds of exception messages, just the ones thrown by `gonzales-pe`. All other messages should just be rethrown and handled further up, for example in the `CLI` or by `gulp-lesshint`.