### PR TITLE
Skip variable declarations in propertyUnits linter

### DIFF
--- a/lib/linters/property_units.js
+++ b/lib/linters/property_units.js
@@ -15,6 +15,9 @@ module.exports = {
         var sprintf = require('sprintf-js').sprintf;
         var self = this;
 
+        if (!node.contains('property') || !node.first('property').contains('ident')) {
+            return null;
+        }
         property = node.first('property').first('ident').content;
         value = node.first('value');
 

--- a/test/specs/linters/property_units.js
+++ b/test/specs/linters/property_units.js
@@ -364,5 +364,21 @@ describe('lesshint', function () {
 
             assert.equal(null, lint(options, ast));
         });
+
+        it('should return null when variable declaration', function () {
+            var source = '.foo { @var-name: 12px; }';
+            var ast;
+
+            var options = {
+                propertyUnits: {
+                    enabled: true,
+                }
+            };
+
+            ast = parseAST(source);
+            ast = ast.first().first('block').first('declaration');
+
+            assert.equal(null, lint(options, ast));
+        });
     });
 });


### PR DESCRIPTION
This MR skips variable declarations inside of classes similar to the example below.

```less
ul {
    @var-name: 25px;
}
```