### PR TITLE
Fix property.start undefined error

### DIFF
--- a/lib/linters/duplicate_property.js
+++ b/lib/linters/duplicate_property.js
@@ -21,8 +21,8 @@ module.exports = {
             if (properties.indexOf(property.content) !== -1) {
                 results.push({
                     message: util.format(self.message, property.content),
-                    column: property.start.column,
-                    line: property.start.line
+                    column: property.start && property.start.column,
+                    line: property.start && property.start.line
                 });
             }
 


### PR DESCRIPTION
```
TypeError: Cannot read property 'column' of undefined
    at /Users/afc163/Projects/ant-design/node_modules/lesshint/lib/linters/duplicate_property.js:23:43
    at Node.forEach (/Users/afc163/Projects/ant-design/node_modules/lesshint/node_modules/gonzales-pe/lib/node/basic-node.js:103:82)
    at Object.duplicatePropertyLinter [as lint] (/Users/afc163/Projects/ant-design/node_modules/lesshint/lib/linters/duplicate_property.js:15:14)
    at /Users/afc163/Projects/ant-design/node_modules/lesshint/lib/linter.js:101:32
    at Array.forEach (native)
    at /Users/afc163/Projects/ant-design/node_modules/lesshint/lib/linter.js:86:17
    at Node.traverse (/Users/afc163/Projects/ant-design/node_modules/lesshint/node_modules/gonzales-pe/lib/node/basic-node.js:207:5)
    at Node.traverse (/Users/afc163/Projects/ant-design/node_modules/lesshint/node_modules/gonzales-pe/lib/node/basic-node.js:212:35)
    at Node.traverse (/Users/afc163/Projects/ant-design/node_modules/lesshint/node_modules/gonzales-pe/lib/node/basic-node.js:212:35)
    at Object.exports.lint (/Users/afc163/Projects/ant-design/node_modules/lesshint/lib/linter.js:85:9)
```