### PR TITLE
feat(linter): selector naming convention #105

### DIFF
--- a/lib/config/defaults.json
+++ b/lib/config/defaults.json
@@ -93,6 +93,12 @@
         "allowWithAttribute": false
     },
 
+    "selectorNaming": {
+        "enabled": false,
+        "disallowUppercase": true,
+        "disallowUnderscore": true
+    },
+
     "singleLinePerProperty": {
         "enabled": true
     },

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -22,6 +22,7 @@ var linters = [
     require('./linters/property_ordering'),
     require('./linters/property_units'),
     require('./linters/qualifying_element'),
+    require('./linters/selector_naming'),
     require('./linters/single_line_per_property'),
     require('./linters/single_line_per_selector'),
     require('./linters/space_after_property_colon'),

--- a/lib/linters/README.md
+++ b/lib/linters/README.md
@@ -19,6 +19,7 @@ Each linter also accept a `enabled` option to turn if off/on completely. It's al
 * [propertyOrdering](#propertyordering)
 * [propertyUnits](#propertyunits)
 * [qualifyingElement](#qualifyingelement)
+* [selectorNaming](#selectornaming)
 * [singleLinePerProperty](#singlelineperproperty)
 * [singleLinePerSelector](#singlelineperselector)
 * [spaceAfterPropertyColon](#spaceafterpropertycolon)
@@ -390,6 +391,59 @@ div#foo {
     color: red;
 }
 ```
+
+## selectorNaming
+
+Option               | Description
+-------------------- | ----------
+`disallowUppercase`  | `true` (**default**), `boolean`
+`disallowUnderscore` | `true` (**default**), `boolean`
+`disallowDash`       | `false` (**default**), `boolean`
+`exclude`            | `string array`
+
+
+```js
+var options = {
+    disallowUppercase: true,
+    disallowUnderscore: true,
+    exclude: ['fooExcluded']
+}
+```
+
+### valid
+
+```less
+.foo-bar {
+
+}
+
+.fooExcluded {
+
+}
+
+```
+
+### invalid
+
+```less
+.fooBar {
+
+}
+
+.foo_bar {
+
+}
+```
+
+Currently this option lets you approximate some naming conventions.
+Keep in mind that it's not foolproof.
+
+Style              | example            | options to enable
+------------------ | ------------------ | -----------------
+train case         | .btn-primary       | `disallowUppercase`, `disallowUnderscore`
+snake case         | .btn_primary       | `disallowUppercase`, `disallowDash`
+camel case         | .btnPrimary        | `disallowUnderscore`, `disallowDash`
+
 
 ## singleLinePerProperty
 Each property should be on its own line.

--- a/lib/linters/selector_naming.js
+++ b/lib/linters/selector_naming.js
@@ -1,0 +1,39 @@
+'use strict';
+
+module.exports = {
+    name: 'selectorNaming',
+    nodeTypes: ['selector'],
+    message: 'Selector should respect naming convention.',
+
+    lint: function selectorNamingLinter (config, node) {
+        var start;
+        var hasErrors;
+        var exclude = config.exclude;
+
+        hasErrors = node.content.some(function (element) {
+            var name = element.first('ident') && element.first('ident').content;
+
+            if (exclude && exclude.indexOf(name) > -1) {
+                return false;
+            }
+
+            if ((config.disallowUppercase === true && name.toLowerCase() !== name) ||
+                (config.disallowUnderscore === true && name.indexOf('_') > -1) ||
+                (config.disallowDash === true && name.indexOf('-') > -1)) {
+
+                start = element.start;
+                return true;
+            }
+
+            return false;
+        });
+
+        if (hasErrors) {
+            return [{
+                column: start.column,
+                line: start.line,
+                message: this.message
+            }];
+        }
+    }
+};

--- a/test/specs/linters/selector_naming.js
+++ b/test/specs/linters/selector_naming.js
@@ -1,0 +1,150 @@
+'use strict';
+
+var path = require('path');
+var expect = require('chai').expect;
+var linter = require('../../../lib/linters/' + path.basename(__filename));
+var parseAST = require('../../../lib/linter').parseAST;
+
+describe('lesshint', function () {
+    describe('#selectorNaming()', function () {
+        var result;
+        var ast;
+        var options;
+
+        it('should check for lowercase', function () {
+            options = {
+                disallowUppercase: true
+            };
+
+            ast = parseAST('.fooBar {}');
+            ast = ast.first().first('selector');
+            result = linter.lint(options, ast);
+            expect(result.length).to.equal(1);
+        });
+
+        it('should check for underscore', function () {
+            options = {
+                disallowUnderscore: true
+            };
+
+            ast = parseAST('.foo_bar {}');
+            ast = ast.first().first('selector');
+            result = linter.lint(options, ast);
+            expect(result.length).to.equal(1);
+        });
+
+        it('should check for dash', function () {
+            options = {
+                disallowDash: true
+            };
+
+            ast = parseAST('.foo-bar {}');
+            ast = ast.first().first('selector');
+            result = linter.lint(options, ast);
+            expect(result.length).to.equal(1);
+        });
+
+        it('should allow exceptions with exclude', function () {
+            options = {
+                disallowDash: true,
+                exclude: ['foo-bar']
+            };
+
+            ast = parseAST('.foo-bar {}');
+            ast = ast.first().first('selector');
+            result = linter.lint(options, ast);
+            expect(result).to.be.undefined;
+        });
+
+        describe('combinations', function () {
+            it('should approximate "camelCase" style', function () {
+                options = {
+                    disallowDash: true,
+                    disallowUnderscore: true
+                };
+
+                ast = parseAST('.foo-bar {}');
+                ast = ast.first().first('selector');
+                result = linter.lint(options, ast);
+                expect(result.length).to.equal(1);
+
+                ast = parseAST('.foo_bar {}');
+                ast = ast.first().first('selector');
+                result = linter.lint(options, ast);
+                expect(result.length).to.equal(1);
+
+                ast = parseAST('.fooBar {}');
+                ast = ast.first().first('selector');
+                result = linter.lint(options, ast);
+                expect(result).to.be.undefined;
+
+                ast = parseAST('.FooBar {}');
+                ast = ast.first().first('selector');
+                result = linter.lint(options, ast);
+                expect(result).to.be.undefined;
+            });
+
+            it('should approximate "snake_case" style', function () {
+                options = {
+                    disallowDash: true
+                };
+
+                ast = parseAST('.foo-bar {}');
+                ast = ast.first().first('selector');
+                result = linter.lint(options, ast);
+                expect(result.length).to.equal(1);
+
+                ast = parseAST('.foo_bar {}');
+                ast = ast.first().first('selector');
+                result = linter.lint(options, ast);
+                expect(result).to.be.undefined;
+
+                options = {
+                    disallowDash: true,
+                    disallowUppercase: true
+                };
+
+                ast = parseAST('.foo_Bar {}');
+                ast = ast.first().first('selector');
+                result = linter.lint(options, ast);
+                expect(result.length).to.equal(1);
+
+                ast = parseAST('.foo_bar {}');
+                ast = ast.first().first('selector');
+                result = linter.lint(options, ast);
+                expect(result).to.be.undefined;
+            });
+
+            it('should approximate "train-case" style', function () {
+                options = {
+                    disallowDash: true
+                };
+
+                ast = parseAST('.foo-bar {}');
+                ast = ast.first().first('selector');
+                result = linter.lint(options, ast);
+                expect(result.length).to.equal(1);
+
+                ast = parseAST('.foo_bar {}');
+                ast = ast.first().first('selector');
+                result = linter.lint(options, ast);
+                expect(result).to.be.undefined;
+
+                options = {
+                    disallowDash: true,
+                    disallowUppercase: true
+                };
+
+                ast = parseAST('.foo_Bar {}');
+                ast = ast.first().first('selector');
+                result = linter.lint(options, ast);
+                expect(result.length).to.equal(1);
+
+                ast = parseAST('.foo_bar {}');
+                ast = ast.first().first('selector');
+                result = linter.lint(options, ast);
+                expect(result).to.be.undefined;
+            });
+        });
+    });
+});


### PR DESCRIPTION
Allows to check for case, dashes and underscores.
Can be combined to approximate camelcase, train, snake case.
One can also add a white list with the excludes option.

Actual naming conventions like camel case or bem notation might be
a second step.

Issue  #105