### PR TITLE
Fix duplicateProperty crashing on local variables

### DIFF
--- a/lib/linters/duplicate_property.js
+++ b/lib/linters/duplicate_property.js
@@ -18,7 +18,7 @@ module.exports = {
 
             property = helpers.ensureObject(property.first('ident'));
 
-            if (properties.indexOf(property.content) !== -1) {
+            if (property.content && (properties.indexOf(property.content) !== -1)) {
                 results.push({
                     message: util.format(self.message, property.content),
                     column: property.start.column,

--- a/test/specs/linters/duplicate_property.js
+++ b/test/specs/linters/duplicate_property.js
@@ -86,5 +86,22 @@ describe('lesshint', function () {
 
             expect(result).to.deep.equal(expected);
         });
+
+        it('should ignore local variables', function () {
+            var source = '.foo { @a: red; @b: 3px; }';
+            var result;
+            var ast;
+
+            var options = {
+                exclude: []
+            };
+
+            ast = parseAST(source);
+            ast = ast.first().first('block');
+
+            result = linter.lint(options, ast);
+
+            expect(result).to.be.undefined;
+        });
     });
 });


### PR DESCRIPTION
Otherwise crashes on:
```less
.myblock {
    @a: red;
    @b: 3px;
 }
```