### PR TITLE
Honor excludedFiles in the config file

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -70,8 +70,11 @@ module.exports = function (program) {
     try {
         config = configLoader(program.config);
         config = config || {};
+        config.excludedFiles = config.excludedFiles || [];
 
-        config.excludedFiles = program.exclude ? [program.exclude] : [];
+        if (program.exclude) {
+            config.excludedFiles.push(program.exclude);
+        }
     } catch (e) {
         console.error("Something's wrong with the config file. Error: " + e.message);
 

--- a/test/data/config/config.json
+++ b/test/data/config/config.json
@@ -1,4 +1,6 @@
 {
+    "excludedFiles": ["vendor.less", "exclude-me-too.less"],
+
     "spaceAfterPropertyColon": {
         "enabled": false,
         "style": "one_space"

--- a/test/data/config/exclude-only-one.json
+++ b/test/data/config/exclude-only-one.json
@@ -1,0 +1,3 @@
+{
+    "excludedFiles": ["vendor.less"]
+}

--- a/test/data/excluded-files/exclude-me-too.less
+++ b/test/data/excluded-files/exclude-me-too.less
@@ -1,0 +1,3 @@
+.foo {
+    margin-bottom:10px;
+}

--- a/test/specs/cli.js
+++ b/test/specs/cli.js
@@ -113,12 +113,39 @@ describe('cli', function () {
         });
     });
 
-    it('should ignore excluded files', function () {
+    it('should ignore excluded files (command-line parameter only)', function () {
         var result;
 
         result = cli({
-            args: [path.dirname(__dirname) + '/data/files'],
+            args: [path.dirname(__dirname) + '/data/excluded-files'],
             exclude: '*.less'
+        });
+
+        return result.then(function (status) {
+            expect(status).to.equal(0);
+        });
+    });
+
+    it('should ignore excluded files (config file only)', function () {
+        var result;
+
+        result = cli({
+            args: [path.dirname(__dirname) + '/data/excluded-files'],
+            config: path.dirname(__dirname) + '/data/config/config.json'
+        });
+
+        return result.then(function (status) {
+            expect(status).to.equal(0);
+        });
+    });
+
+    it('should ignore excluded files (both command-line parameter and config file)', function () {
+        var result;
+
+        result = cli({
+            args: [path.dirname(__dirname) + '/data/excluded-files'],
+            config: path.dirname(__dirname) + '/data/config/exclude-only-one.json',
+            exclude: 'exclude-me-too.less'
         });
 
         return result.then(function (status) {

--- a/test/specs/config-loader.js
+++ b/test/specs/config-loader.js
@@ -13,6 +13,8 @@ describe('config-loader', function () {
         var result;
 
         var expected = {
+            excludedFiles: ['vendor.less', 'exclude-me-too.less'],
+
             spaceAfterPropertyColon: {
                 enabled: false,
                 style: 'one_space'

--- a/test/specs/lesshint.js
+++ b/test/specs/lesshint.js
@@ -40,7 +40,7 @@ describe('lesshint', function () {
             lesshint.configure(config);
 
             return lesshint.checkDirectory(testPath).then(function (result) {
-                expect(result).to.have.length(0);
+                expect(result).to.have.length(1);
             });
         });
 
@@ -54,7 +54,7 @@ describe('lesshint', function () {
             lesshint.configure(config);
 
             return lesshint.checkDirectory(testPath).then(function (result) {
-                expect(result).to.have.length(1);
+                expect(result).to.have.length(2);
             });
         });
 
@@ -68,7 +68,7 @@ describe('lesshint', function () {
             lesshint.configure(config);
 
             return lesshint.checkDirectory(testPath).then(function (result) {
-                expect(result).to.have.length(1);
+                expect(result).to.have.length(2);
             });
         });
 
@@ -82,7 +82,7 @@ describe('lesshint', function () {
             lesshint.configure(config);
 
             return lesshint.checkDirectory(testPath).then(function (result) {
-                expect(result).to.have.length(2);
+                expect(result).to.have.length(3);
             });
         });
     });


### PR DESCRIPTION
The current code tramples the excludedFiles setting in the config file
with either the value supplied on the command line or an empty array.
This fixes that; additionally, if excludedFiles is specified in both
the config file and on the command line, the union of both is used.

Tests have been updated/added to cover the different scenarios.