### PR TITLE
fixes #134 bug known as 'trailingWhitespace outputs unexpected syntax…

### DIFF
--- a/lib/linters/trailing_whitespace.js
+++ b/lib/linters/trailing_whitespace.js
@@ -9,8 +9,14 @@ module.exports = {
         var results = [];
         var self = this;
 
+
+        //Ignore empty files
+        if (node.content.length === 0) {
+            return;
+        }
         // We'll convert the AST to the Less source and just loop through each line
         node = node.toString('less') || '';
+
         node.split('\n').forEach(function (line, index) {
             if (/[ \t]+$/g.test(line)) {
                 results.push({


### PR DESCRIPTION
@jwilsson - I only check if the content of node is not empty to prevent forEach operation.