### PR TITLE
spaceAroundComma & spaceBetweenParents - multiline friendly

### DIFF
--- a/lib/linters/space_around_comma.js
+++ b/lib/linters/space_around_comma.js
@@ -12,64 +12,76 @@ module.exports = {
         var self = this;
 
         node.forEach('operator', function (element, index) {
-            var startElement;
-            var nextElement;
-            var prevElement;
-            var message;
+            var next = node.content[index + 1];
+            var prev = node.content[index - 1];
 
             if (element.content !== ',') {
                 return;
             }
 
-            nextElement = node.content[index + 1];
-            prevElement = node.content[index - 1];
-
-            // setting `startElement` equal to nextElement as the default for
-            // `style`is `after`
-            startElement = nextElement;
-
             switch (config.style) {
                 case 'after':
-                    if (nextElement.type !== 'space' || nextElement.content !== ' ') {
-                        message = util.format(self.message, '', 'followed', 'one');
+                    if (next.type !== 'space' || next.content !== ' ' && next.content.indexOf('\n') !== 0) {
+                        results.push({
+                            column: next.start.column,
+                            line: next.start.line,
+                            message: util.format(self.message, '', 'followed', 'one')
+                        });
                     }
-                    break;
 
+                    if (prev.type === 'space' && prev.content === ' ') {
+                        results.push({
+                            column: prev.end.column,
+                            line: prev.end.line,
+                            message: util.format(self.message, ' not', 'preceded', 'any')
+                        });
+                    }
+
+                    break;
                 case 'before':
-                    if (prevElement.type !== 'space' || prevElement.content !== ' ') {
-                        startElement = prevElement;
-                        message = util.format(self.message, '', 'preceded', 'one');
+                    if (prev.type !== 'space' || prev.content !== ' ') {
+                        results.push({
+                            column: prev.end.column,
+                            line: prev.end.line,
+                            message: util.format(self.message, '', 'preceded', 'one')
+                        });
                     }
-                    break;
 
+                    if (next.type === 'space' && next.content === ' ') {
+                        results.push({
+                            column: next.start.column,
+                            line: next.start.line,
+                            message: util.format(self.message, ' not', 'followed', 'any')
+                        });
+                    }
+
+                    break;
                 case 'both':
-                    if (nextElement.type !== 'space' || nextElement.content !== ' ' || !/^\s/.test(nextElement.content) ||
-                       (prevElement.type !== 'space' || prevElement.content !== ' ') || !/\s$/.test(prevElement.content)) {
-
-                        startElement = !/\s$/.test(prevElement.content) ? prevElement : nextElement;
-                        message = util.format(self.message, '', 'preceded and followed', 'one');
+                    if (next.type !== 'space' || next.content !== ' ' || !/^\s/.test(next.content) ||
+                       (prev.type !== 'space' || prev.content !== ' ') || !/\s$/.test(prev.content)
+                    ) {
+                        results.push({
+                            column: (!/\s$/.test(prev.content) ? prev.end : next.start).column,
+                            line: (!/\s$/.test(prev.content) ? prev.end : next.start).line,
+                            message: util.format(self.message, '', 'preceded and followed', 'one')
+                        });
                     }
-                    break;
 
+                    break;
                 case 'none':
-                    if (nextElement.type === 'space' || prevElement.type === 'space') {
-                        startElement = prevElement.type === 'space' ? prevElement : nextElement;
-                        message = util.format(self.message, ' not', 'preceded nor followed', 'any');
+                    if (next.type === 'space' || prev.type === 'space') {
+                        results.push({
+                            column: (prev.type === 'space' ? prev.end : next.start).column,
+                            line: (prev.type === 'space' ? prev.end : next.start).line,
+                            message: util.format(self.message, ' not', 'preceded nor followed', 'any')
+                        });
                     }
-                    break;
 
+                    break;
                 default:
                     throw new Error(
                         'Invalid setting value for spaceAfterComma: ' + config.style
                     );
-            }
-
-            if (message) {
-                results.push({
-                    column: startElement.start.column,
-                    line: startElement.start.line,
-                    message: message
-                });
             }
         });
 

--- a/lib/linters/space_between_parens.js
+++ b/lib/linters/space_between_parens.js
@@ -18,7 +18,7 @@ module.exports = {
 
         switch (config.style) {
             case 'no_space':
-                if (first.type === 'space') {
+                if (first.type === 'space' && first.content.indexOf('\n') !== 0) {
                     results.push({
                         column: first.start.column,
                         line: first.start.line,
@@ -26,7 +26,7 @@ module.exports = {
                     });
                 }
 
-                if (last.type === 'space') {
+                if (last.type === 'space' && first.content.indexOf('\n') !== 0) {
                     results.push({
                         column: last.start.column,
                         line: last.start.line,

--- a/test/specs/linters/space_around_comma.js
+++ b/test/specs/linters/space_around_comma.js
@@ -25,7 +25,7 @@ describe('lesshint', function () {
         });
 
         it('should not allow missing space after comma when "style" is "after"', function () {
-            var source = '.foo { color: rgb(255,255,255); }';
+            var source = '.foo { color: rgb(255,255 ,255); }';
             var result;
             var ast;
 
@@ -35,9 +35,14 @@ describe('lesshint', function () {
                 message: 'Commas should be followed by one space.'
             },
             {
-                column: 27,
+                column: 28,
                 line: 1,
                 message: 'Commas should be followed by one space.'
+            },
+            {
+                column: 26,
+                line: 1,
+                message: 'Commas should not be preceded by any space.'
             }];
 
             var options = {
@@ -132,14 +137,24 @@ describe('lesshint', function () {
             var ast;
 
             var expected = [{
-                column: 19,
+                column: 21,
                 line: 1,
                 message: 'Commas should be preceded by one space.'
             },
             {
-                column: 24,
+                column: 23,
+                line: 1,
+                message: 'Commas should not be followed by any space.'
+            },
+            {
+                column: 26,
                 line: 1,
                 message: 'Commas should be preceded by one space.'
+            },
+            {
+                column: 28,
+                line: 1,
+                message: 'Commas should not be followed by any space.'
             }];
 
             var options = {
@@ -177,9 +192,14 @@ describe('lesshint', function () {
             var ast;
 
             var expected = [{
-                column: 8,
+                column: 14,
                 line: 1,
                 message: 'Commas should be preceded by one space.'
+            },
+            {
+                column: 16,
+                line: 1,
+                message: 'Commas should not be followed by any space.'
             }];
 
             var options = {
@@ -234,12 +254,12 @@ describe('lesshint', function () {
             var ast;
 
             var expected = [{
-                column: 19,
+                column: 21,
                 line: 1,
                 message: 'Commas should be preceded and followed by one space.'
             },
             {
-                column: 24,
+                column: 26,
                 line: 1,
                 message: 'Commas should be preceded and followed by one space.'
             }];
@@ -307,7 +327,7 @@ describe('lesshint', function () {
             var ast;
 
             var expected = [{
-                column: 8,
+                column: 14,
                 line: 1,
                 message: 'Commas should be preceded and followed by one space.'
             }];


### PR DESCRIPTION
fixes #119 & fixes #130

Extra checking other side
`spaceAroundComma` with option `after` or `before` were positive on `rgb(100 , 100 , 100)`

Fixed reporting of column number with prev elements. Prev should report `end.column` not `start.column`.