### PR TITLE
Skip zeroUnit when the property is supposed to have a non-unit number.

### DIFF
--- a/lib/linters/zero_unit.js
+++ b/lib/linters/zero_unit.js
@@ -14,6 +14,13 @@ module.exports = {
         var number;
         var value;
         var unit;
+        var excludeProperties = ['opacity', 'z-index'];
+        var property = node.first('property').first('ident').content;
+
+        // Property doesn't have units, abort
+        if (property && excludeProperties.indexOf(property) !== -1) {
+            return null;
+        }
 
         node.forEach('value', function (element) {
             value = element.first('dimension');

--- a/lib/linters/zero_unit.js
+++ b/lib/linters/zero_unit.js
@@ -14,7 +14,7 @@ module.exports = {
         var number;
         var value;
         var unit;
-        var excludeProperties = ['opacity', 'z-index'];
+        var excludeProperties = ['opacity', 'z-index', 'line-height'];
         var property = node.first('property').first('ident').content;
 
         // Property doesn't have units, abort

--- a/test/specs/linters/zero_unit.js
+++ b/test/specs/linters/zero_unit.js
@@ -121,6 +121,23 @@ describe('lesshint', function () {
             expect(result).to.equal(null);
         });
 
+        it('should not report units on zero values when the the property does not have units and "style" is "no_unit"', function () {
+            var source = '.foo { opacity: 0; }';
+            var result;
+            var ast;
+
+            var options = {
+                style: 'no_unit'
+            };
+
+            ast = parseAST(source);
+            ast = ast.first().first('block').first('declaration');
+
+            result = linter.lint(options, ast);
+
+            expect(result).to.equal(null);
+        });
+
         it('should throw on invalid "style" value', function () {
             var source = '.foo { margin-right: 0; }';
             var lint;


### PR DESCRIPTION
@jwilsson This should take care of #152, let me know if you have any feedback.