### PR TITLE
New option for "spaceAfterPropertyColon" linter

### DIFF
--- a/lib/linters/space_after_property_colon.js
+++ b/lib/linters/space_after_property_colon.js
@@ -8,7 +8,8 @@ module.exports = {
     nodeTypes: ['declaration'],
     message: {
         noSpace: 'Colon after property name should not be followed by any spaces.',
-        oneSpace: 'Colon after property name should be followed by one space.'
+        oneSpace: 'Colon after property name should be followed by one space.',
+        atLeastOneSpace: 'Colon after property name should be followed by at least one space.'
     },
 
     lint: function spaceAfterPropertyColonLinter (config, node) {
@@ -16,6 +17,7 @@ module.exports = {
         var valid = true;
         var checkIndex;
         var maybeSpace;
+        var message;
 
         // Find the colon (south of the spleen)
         checkIndex = findIndex(node.content, function (element) {
@@ -30,11 +32,23 @@ module.exports = {
                     valid = false;
                 }
 
+                message = this.message.noSpace;
+
                 break;
             case 'one_space':
                 if (maybeSpace.type !== 'space' || (maybeSpace.type === 'space' && maybeSpace.content !== ' ')) {
                     valid = false;
                 }
+
+                message = this.message.oneSpace;
+
+                break;
+            case 'at_least_one_space':
+                if (maybeSpace.type !== 'space') {
+                    valid = false;
+                }
+
+                message = this.message.atLeastOneSpace;
 
                 break;
             default:
@@ -47,7 +61,7 @@ module.exports = {
             return [{
                 column: maybeSpace.start.column,
                 line: maybeSpace.start.line,
-                message: util.format(style === 'no_space' ? this.message.noSpace : this.message.oneSpace)
+                message: util.format(message)
             }];
         }
     }

--- a/test/specs/linters/space_after_property_colon.js
+++ b/test/specs/linters/space_after_property_colon.js
@@ -7,6 +7,63 @@ var parseAST = require('../../../lib/linter').parseAST;
 
 describe('lesshint', function () {
     describe('#spaceAfterPropertyColon()', function () {
+        it('should allow one space when "style" is "at_least_one_space"', function () {
+            var source = '.foo { color: red; }';
+            var result;
+            var ast;
+
+            var options = {
+                style: 'at_least_one_space'
+            };
+
+            ast = parseAST(source);
+            ast = ast.first().first('block').first('declaration');
+
+            result = linter.lint(options, ast);
+
+            expect(result).to.be.undefined;
+        });
+
+        it('should not tolerate missing space when "style" is "at_least_one_space"', function () {
+            var source = '.foo { color:red; }';
+            var result;
+            var ast;
+
+            var expected = [{
+                column: 14,
+                line: 1,
+                message: 'Colon after property name should be followed by at least one space.'
+            }];
+
+            var options = {
+                style: 'at_least_one_space'
+            };
+
+            ast = parseAST(source);
+            ast = ast.first().first('block').first('declaration');
+
+            result = linter.lint(options, ast);
+
+            expect(result).to.deep.equal(expected);
+        });
+
+        it('should allow more than one space when "style" is "at_least_one_space"', function () {
+            var source = '.foo { color:  red; }';
+            var result;
+            var ast;
+
+            var options = {
+                style: 'at_least_one_space'
+            };
+
+            ast = parseAST(source);
+            ast = ast.first().first('block').first('declaration');
+
+            result = linter.lint(options, ast);
+
+            expect(result).to.be.undefined;
+        });
+
         it('should allow one space when "style" is "one_space"', function () {
             var source = '.foo { color: red; }';
             var result;


### PR DESCRIPTION
Adds "at_least_one_space" option to "spaceAfterPropertyColon" linter. Thats allows to align equal values  of related properties. Like so:
```
.foo {
    width:  20px;
    height: 20px;
}
```
Resolves #154 