### PR TITLE
brings zeroUnit inline with the spec, provides config for both units and property names.

### DIFF
--- a/lib/linters/README.md
+++ b/lib/linters/README.md
@@ -800,9 +800,11 @@ The [CSS spec](http://dev.w3.org/csswg/css-values/#url-value) also recommends th
 ## zeroUnit
 Zero values should include a unit for consistency with other values.
 
-Option     | Description
----------- | ----------
-`style`    | `no_unit`, `keep_unit` (**default**)
+Option      | Description
+------------| ----------
+`style`     | `no_unit`, `keep_unit` (**default**)
+`units`     | `string array` additional units to enforce.
+`ignore`    | `string array` additional properties to ignore.
 
 ### no_unit
 ```less

--- a/lib/linters/zero_unit.js
+++ b/lib/linters/zero_unit.js
@@ -14,6 +14,23 @@ module.exports = {
         var number;
         var value;
         var unit;
+        var ignoredProperties = ['opacity', 'z-index'];
+        var property = node.first('property').first('ident').content;
+
+        if (config) {
+            if (config.ignore && config.ignore.length) {
+                ignoredProperties.push(config.ignore);
+            }
+
+            if (config.units && config.units.length) {
+                units.push(config.units);
+            }
+        }
+
+        // The property shouldn't be checked for units
+        if (property && ignoredProperties.indexOf(property) !== -1) {
+            return;
+        }
 
         node.forEach('value', function (element) {
             value = element.first('dimension');
@@ -30,12 +47,12 @@ module.exports = {
 
         // Nothing to lint found, bail
         if (!number || parseFloat(number.content) !== 0) {
-            return null;
+            return;
         }
 
         // Unit is required, nothing to do
         if (unit && units.indexOf(unit.content) === -1) {
-            return null;
+            return;
         }
 
         number = number.content;
@@ -54,9 +71,7 @@ module.exports = {
 
                 break;
             default:
-                throw new Error(
-                    'Invalid setting value for zeroUnit: ' + config.style
-                );
+                throw new Error('Invalid setting value for zeroUnit: ' + config.style);
         }
 
         if (!valid) {

--- a/test/specs/linters/zero_unit.js
+++ b/test/specs/linters/zero_unit.js
@@ -101,7 +101,7 @@ describe('lesshint', function () {
 
             result = linter.lint(options, ast);
 
-            expect(result).to.equal(null);
+            expect(result).to.be.undefined;
         });
 
         it('should not report units on zero values when the unit is a time and "style" is "no_unit"', function () {
@@ -118,7 +118,60 @@ describe('lesshint', function () {
 
             result = linter.lint(options, ast);
 
-            expect(result).to.equal(null);
+            expect(result).to.be.undefined;
+        });
+
+        it('should not report units on zero values when the unit is configured and "style" is "no_unit"', function () {
+            var source = '.foo { margin-left: 0zz; }';
+            var result;
+            var ast;
+
+            var options = {
+                style: 'no_unit',
+                units: ['zz']
+            };
+
+            ast = parseAST(source);
+            ast = ast.first().first('block').first('declaration');
+
+            result = linter.lint(options, ast);
+
+            expect(result).to.be.undefined;
+        });
+
+        it('should not report units on zero values when the the property does not have units and "style" is "no_unit"', function () {
+            var source = '.bar { z-index: 0; }';
+            var result;
+            var ast;
+
+            var options = {
+                style: 'no_unit'
+            };
+
+            ast = parseAST(source);
+            ast = ast.first().first('block').first('declaration');
+
+            result = linter.lint(options, ast);
+
+            expect(result).to.be.undefined;
+        });
+
+        it('should not report units on zero values when the the property does not have units and "style" is "no_unit"', function () {
+            var source = '.bar { margin-left: 0; }';
+            var result;
+            var ast;
+
+            var options = {
+                style: 'no_unit',
+                ignore: ['margin-left']
+            };
+
+            ast = parseAST(source);
+            ast = ast.first().first('block').first('declaration');
+
+            result = linter.lint(options, ast);
+
+            expect(result).to.be.undefined;
         });
 
         it('should throw on invalid "style" value', function () {


### PR DESCRIPTION
Not sure why #153 was closed and the fork was deleted, but this PR contains the same work done by @ajaswa, with the added option of allowing users to add units and excluded properties to the existing list.