### PR TITLE
synchronous gulp task execution, linter indentation fixes

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,13 +10,13 @@ gulp.task('lint', function () {
         .pipe(eslint.failAfterError());
 });
 
-gulp.task('coverage', function () {
+gulp.task('coverage', ['lint'], function () {
     return gulp.src(['./lib/**/*.js'])
         .pipe(istanbul())
         .pipe(istanbul.hookRequire());
 });
 
-gulp.task('test', ['lint', 'coverage'], function () {
+gulp.task('test', ['coverage'], function () {
     var mocha = require('gulp-mocha');
 
     return gulp.src(['./test/specs/**/*.js'])

--- a/test/specs/linter.js
+++ b/test/specs/linter.js
@@ -90,46 +90,48 @@ describe('linter', function () {
             var path = 'path/to/file.less';
             var result;
 
-            var expected = [{
-                column: 7,
-                file: 'file.less',
-                fullPath: 'path/to/file.less',
-                line: 1,
-                linter: 'stringQuotes',
-                message: 'Strings should use single quotes.',
-                severity: 'warning',
-                source: '[type="text"], [type=email] {'
-            },
-            {
-                column: 22,
-                file: 'file.less',
-                fullPath: 'path/to/file.less',
-                line: 1,
-                linter: 'attributeQuotes',
-                message: 'Attribute selectors should use quotes.',
-                severity: 'warning',
-                source: '[type="text"], [type=email] {'
-            },
-            {
-                column: 1,
-                file: 'file.less',
-                fullPath: 'path/to/file.less',
-                line: 3,
-                linter: 'propertyOrdering',
-                message: 'Property ordering is not alphabetized',
-                severity: 'warning',
-                source: 'color: red;'
-            },
-            {
-                column: 1,
-                file: 'file.less',
-                fullPath: 'path/to/file.less',
-                line: 4,
-                linter: 'duplicateProperty',
-                message: 'Duplicate property: "color".',
-                severity: 'warning',
-                source: 'color: blue;'
-            }];
+            var expected = [
+                {
+                    column: 7,
+                    file: 'file.less',
+                    fullPath: 'path/to/file.less',
+                    line: 1,
+                    linter: 'stringQuotes',
+                    message: 'Strings should use single quotes.',
+                    severity: 'warning',
+                    source: '[type="text"], [type=email] {'
+                },
+                {
+                    column: 22,
+                    file: 'file.less',
+                    fullPath: 'path/to/file.less',
+                    line: 1,
+                    linter: 'attributeQuotes',
+                    message: 'Attribute selectors should use quotes.',
+                    severity: 'warning',
+                    source: '[type="text"], [type=email] {'
+                },
+                {
+                    column: 1,
+                    file: 'file.less',
+                    fullPath: 'path/to/file.less',
+                    line: 3,
+                    linter: 'propertyOrdering',
+                    message: 'Property ordering is not alphabetized',
+                    severity: 'warning',
+                    source: 'color: red;'
+                },
+                {
+                    column: 1,
+                    file: 'file.less',
+                    fullPath: 'path/to/file.less',
+                    line: 4,
+                    linter: 'duplicateProperty',
+                    message: 'Duplicate property: "color".',
+                    severity: 'warning',
+                    source: 'color: blue;'
+                }
+            ];
 
             var config = {
                 attributeQuotes: {

--- a/test/specs/linters/import_path.js
+++ b/test/specs/linters/import_path.js
@@ -198,16 +198,18 @@ describe('lesshint', function () {
             var result;
             var ast;
 
-            var expected = [{
-                column: 9,
-                line: 1,
-                message: 'Imported file, "_foo.less" should not include the file extension.'
-            },
-            {
-                column: 9,
-                line: 1,
-                message: 'Imported file, "_foo.less" should not include a leading underscore.'
-            }];
+            var expected = [
+                {
+                    column: 9,
+                    line: 1,
+                    message: 'Imported file, "_foo.less" should not include the file extension.'
+                },
+                {
+                    column: 9,
+                    line: 1,
+                    message: 'Imported file, "_foo.less" should not include a leading underscore.'
+                }
+            ];
 
             var options = {
                 filenameExtension: false,

--- a/test/specs/linters/single_line_per_property.js
+++ b/test/specs/linters/single_line_per_property.js
@@ -25,16 +25,18 @@ describe('lesshint', function () {
             var result;
             var ast;
 
-            var expected = [{
-                column: 2,
-                line: 2,
-                message: 'Each property should be on its own line.'
-            },
-            {
-                column: 14,
-                line: 2,
-                message: 'Each property should be on its own line.'
-            }];
+            var expected = [
+                {
+                    column: 2,
+                    line: 2,
+                    message: 'Each property should be on its own line.'
+                },
+                {
+                    column: 14,
+                    line: 2,
+                    message: 'Each property should be on its own line.'
+                }
+            ];
 
             ast = parseAST(source);
             ast = ast.first('ruleset').first('block');
@@ -273,16 +275,18 @@ describe('lesshint', function () {
             var result;
             var ast;
 
-            var expected = [{
-                column: 2,
-                line: 2,
-                message: 'Each property should be on its own line.'
-            },
-            {
-                column: 14,
-                line: 2,
-                message: 'Each property should be on its own line.'
-            }];
+            var expected = [
+                {
+                    column: 2,
+                    line: 2,
+                    message: 'Each property should be on its own line.'
+                },
+                {
+                    column: 14,
+                    line: 2,
+                    message: 'Each property should be on its own line.'
+                }
+            ];
 
             ast = parseAST(source);
             ast = ast.first('ruleset').first('block');
@@ -297,16 +301,18 @@ describe('lesshint', function () {
             var result;
             var ast;
 
-            var expected = [{
-                column: 2,
-                line: 2,
-                message: 'Each property should be on its own line.'
-            },
-            {
-                column: 14,
-                line: 2,
-                message: 'Each property should be on its own line.'
-            }];
+            var expected = [
+                {
+                    column: 2,
+                    line: 2,
+                    message: 'Each property should be on its own line.'
+                },
+                {
+                    column: 14,
+                    line: 2,
+                    message: 'Each property should be on its own line.'
+                }
+            ];
 
             ast = parseAST(source);
             ast = ast.first('ruleset').first('block');

--- a/test/specs/linters/space_after_property_value.js
+++ b/test/specs/linters/space_after_property_value.js
@@ -92,16 +92,18 @@ describe('lesshint', function () {
             var result;
             var ast;
 
-            var expected = [{
-                column: 18,
-                line: 1,
-                message: 'Semicolon after property value should not be preceded by any space.',
-            },
-            {
-                column: 39,
-                line: 1,
-                message: 'Semicolon after property value should not be preceded by any space.'
-            }];
+            var expected = [
+                {
+                    column: 18,
+                    line: 1,
+                    message: 'Semicolon after property value should not be preceded by any space.',
+                },
+                {
+                    column: 39,
+                    line: 1,
+                    message: 'Semicolon after property value should not be preceded by any space.'
+                }
+            ];
 
             var options = {
                 style: 'no_space'
@@ -120,16 +122,18 @@ describe('lesshint', function () {
             var result;
             var ast;
 
-            var expected = [{
-                column: 8,
-                line: 1,
-                message: 'Semicolon after property value should be preceded by one space.'
-            },
-            {
-                column: 20,
-                line: 1,
-                message: 'Semicolon after property value should be preceded by one space.'
-            }];
+            var expected = [
+                {
+                    column: 8,
+                    line: 1,
+                    message: 'Semicolon after property value should be preceded by one space.'
+                },
+                {
+                    column: 20,
+                    line: 1,
+                    message: 'Semicolon after property value should be preceded by one space.'
+                }
+            ];
 
             var options = {
                 style: 'one_space'

--- a/test/specs/linters/space_around_comma.js
+++ b/test/specs/linters/space_around_comma.js
@@ -29,16 +29,18 @@ describe('lesshint', function () {
             var result;
             var ast;
 
-            var expected = [{
-                column: 23,
-                line: 1,
-                message: 'Commas should be followed by one space.'
-            },
-            {
-                column: 27,
-                line: 1,
-                message: 'Commas should be followed by one space.'
-            }];
+            var expected = [
+                {
+                    column: 23,
+                    line: 1,
+                    message: 'Commas should be followed by one space.'
+                },
+                {
+                    column: 27,
+                    line: 1,
+                    message: 'Commas should be followed by one space.'
+                }
+            ];
 
             var options = {
                 style: 'after'
@@ -131,16 +133,18 @@ describe('lesshint', function () {
             var result;
             var ast;
 
-            var expected = [{
-                column: 19,
-                line: 1,
-                message: 'Commas should be preceded by one space.'
-            },
-            {
-                column: 24,
-                line: 1,
-                message: 'Commas should be preceded by one space.'
-            }];
+            var expected = [
+                {
+                    column: 19,
+                    line: 1,
+                    message: 'Commas should be preceded by one space.'
+                },
+                {
+                    column: 24,
+                    line: 1,
+                    message: 'Commas should be preceded by one space.'
+                }
+            ];
 
             var options = {
                 style: 'before'
@@ -233,16 +237,18 @@ describe('lesshint', function () {
             var result;
             var ast;
 
-            var expected = [{
-                column: 19,
-                line: 1,
-                message: 'Commas should be preceded and followed by one space.'
-            },
-            {
-                column: 24,
-                line: 1,
-                message: 'Commas should be preceded and followed by one space.'
-            }];
+            var expected = [
+                {
+                    column: 19,
+                    line: 1,
+                    message: 'Commas should be preceded and followed by one space.'
+                },
+                {
+                    column: 24,
+                    line: 1,
+                    message: 'Commas should be preceded and followed by one space.'
+                }
+            ];
 
             var options = {
                 style: 'both'
@@ -261,16 +267,18 @@ describe('lesshint', function () {
             var result;
             var ast;
 
-            var expected = [{
-                column: 24,
-                line: 1,
-                message: 'Commas should be preceded and followed by one space.'
-            },
-            {
-                column: 29,
-                line: 1,
-                message: 'Commas should be preceded and followed by one space.'
-            }];
+            var expected = [
+                {
+                    column: 24,
+                    line: 1,
+                    message: 'Commas should be preceded and followed by one space.'
+                },
+                {
+                    column: 29,
+                    line: 1,
+                    message: 'Commas should be preceded and followed by one space.'
+                }
+            ];
 
             var options = {
                 style: 'both'
@@ -373,16 +381,18 @@ describe('lesshint', function () {
                 style: 'none'
             };
 
-            var expected = [{
-                column: 23,
-                line: 1,
-                message: 'Commas should not be preceded nor followed by any space.'
-            },
-            {
-                column: 28,
-                line: 1,
-                message: 'Commas should not be preceded nor followed by any space.'
-            }];
+            var expected = [
+                {
+                    column: 23,
+                    line: 1,
+                    message: 'Commas should not be preceded nor followed by any space.'
+                },
+                {
+                    column: 28,
+                    line: 1,
+                    message: 'Commas should not be preceded nor followed by any space.'
+                }
+            ];
 
             ast = parseAST(source);
             ast = ast.first().first('block').first('declaration').first('value').first('function').first('arguments');
@@ -397,16 +407,18 @@ describe('lesshint', function () {
             var result;
             var ast;
 
-            var expected = [{
-                column: 22,
-                line: 1,
-                message: 'Commas should not be preceded nor followed by any space.'
-            },
-            {
-                column: 27,
-                line: 1,
-                message: 'Commas should not be preceded nor followed by any space.'
-            }];
+            var expected = [
+                {
+                    column: 22,
+                    line: 1,
+                    message: 'Commas should not be preceded nor followed by any space.'
+                },
+                {
+                    column: 27,
+                    line: 1,
+                    message: 'Commas should not be preceded nor followed by any space.'
+                }
+            ];
 
             var options = {
                 style: 'none'
@@ -522,16 +534,18 @@ describe('lesshint', function () {
             var result;
             var ast;
 
-            var expected = [{
-                column: 23,
-                line: 1,
-                message: 'Commas should not be preceded nor followed by any space.'
-            },
-            {
-                column: 28,
-                line: 1,
-                message: 'Commas should not be preceded nor followed by any space.'
-            }];
+            var expected = [
+                {
+                    column: 23,
+                    line: 1,
+                    message: 'Commas should not be preceded nor followed by any space.'
+                },
+                {
+                    column: 28,
+                    line: 1,
+                    message: 'Commas should not be preceded nor followed by any space.'
+                }
+            ];
 
             var options = {
                 style: 'none'

--- a/test/specs/linters/space_between_parens.js
+++ b/test/specs/linters/space_between_parens.js
@@ -109,16 +109,18 @@ describe('lesshint', function () {
             var result;
             var ast;
 
-            var expected = [{
-                column: 19,
-                line: 1,
-                message: 'Opening parenthesis should not be followed by any space.'
-            },
-            {
-                column: 33,
-                line: 1,
-                message: 'Closing parenthesis should not be preceded by any space.'
-            }];
+            var expected = [
+                {
+                    column: 19,
+                    line: 1,
+                    message: 'Opening parenthesis should not be followed by any space.'
+                },
+                {
+                    column: 33,
+                    line: 1,
+                    message: 'Closing parenthesis should not be preceded by any space.'
+                }
+            ];
 
             var options = {
                 style: 'no_space'
@@ -183,16 +185,18 @@ describe('lesshint', function () {
             var result;
             var ast;
 
-            var expected = [{
-                column: 19,
-                line: 1,
-                message: 'Opening parenthesis should not be followed by any space.'
-            },
-            {
-                column: 34,
-                line: 1,
-                message: 'Closing parenthesis should not be preceded by any space.'
-            }];
+            var expected = [
+                {
+                    column: 19,
+                    line: 1,
+                    message: 'Opening parenthesis should not be followed by any space.'
+                },
+                {
+                    column: 34,
+                    line: 1,
+                    message: 'Closing parenthesis should not be preceded by any space.'
+                }
+            ];
 
             var options = {
                 style: 'no_space'
@@ -308,16 +312,18 @@ describe('lesshint', function () {
             var result;
             var ast;
 
-            var expected = [{
-                column: 19,
-                line: 1,
-                message: 'Opening parenthesis should be followed by one space.'
-            },
-            {
-                column: 29,
-                line: 1,
-                message: 'Closing parenthesis should be preceded by one space.'
-            }];
+            var expected = [
+                {
+                    column: 19,
+                    line: 1,
+                    message: 'Opening parenthesis should be followed by one space.'
+                },
+                {
+                    column: 29,
+                    line: 1,
+                    message: 'Closing parenthesis should be preceded by one space.'
+                }
+            ];
 
             var options = {
                 style: 'one_space'
@@ -382,16 +388,18 @@ describe('lesshint', function () {
             var result;
             var ast;
 
-            var expected = [{
-                column: 19,
-                line: 1,
-                message: 'Opening parenthesis should be followed by one space.'
-            },
-            {
-                column: 34,
-                line: 1,
-                message: 'Closing parenthesis should be preceded by one space.'
-            }];
+            var expected = [
+                {
+                    column: 19,
+                    line: 1,
+                    message: 'Opening parenthesis should be followed by one space.'
+                },
+                {
+                    column: 34,
+                    line: 1,
+                    message: 'Closing parenthesis should be preceded by one space.'
+                }
+            ];
 
             var options = {
                 style: 'one_space'
@@ -507,16 +515,18 @@ describe('lesshint', function () {
             var result;
             var ast;
 
-            var expected = [{
-                column: 8,
-                line: 1,
-                message: 'Opening parenthesis should not be followed by any space.'
-            },
-            {
-                column: 26,
-                line: 1,
-                message: 'Closing parenthesis should not be preceded by any space.'
-            }];
+            var expected = [
+                {
+                    column: 8,
+                    line: 1,
+                    message: 'Opening parenthesis should not be followed by any space.'
+                },
+                {
+                    column: 26,
+                    line: 1,
+                    message: 'Closing parenthesis should not be preceded by any space.'
+                }
+            ];
 
             var options = {
                 style: 'no_space'
@@ -581,16 +591,18 @@ describe('lesshint', function () {
             var result;
             var ast;
 
-            var expected = [{
-                column: 8,
-                line: 1,
-                message: 'Opening parenthesis should not be followed by any space.'
-            },
-            {
-                column: 27,
-                line: 1,
-                message: 'Closing parenthesis should not be preceded by any space.'
-            }];
+            var expected = [
+                {
+                    column: 8,
+                    line: 1,
+                    message: 'Opening parenthesis should not be followed by any space.'
+                },
+                {
+                    column: 27,
+                    line: 1,
+                    message: 'Closing parenthesis should not be preceded by any space.'
+                }
+            ];
 
             var options = {
                 style: 'no_space'
@@ -706,16 +718,18 @@ describe('lesshint', function () {
             var result;
             var ast;
 
-            var expected = [{
-                column: 8,
-                line: 1,
-                message: 'Opening parenthesis should be followed by one space.'
-            },
-            {
-                column: 17,
-                line: 1,
-                message: 'Closing parenthesis should be preceded by one space.'
-            }];
+            var expected = [
+                {
+                    column: 8,
+                    line: 1,
+                    message: 'Opening parenthesis should be followed by one space.'
+                },
+                {
+                    column: 17,
+                    line: 1,
+                    message: 'Closing parenthesis should be preceded by one space.'
+                }
+            ];
 
             var options = {
                 style: 'one_space'
@@ -780,16 +794,18 @@ describe('lesshint', function () {
             var result;
             var ast;
 
-            var expected = [{
-                column: 8,
-                line: 1,
-                message: 'Opening parenthesis should be followed by one space.'
-            },
-            {
-                column: 27,
-                line: 1,
-                message: 'Closing parenthesis should be preceded by one space.'
-            }];
+            var expected = [
+                {
+                    column: 8,
+                    line: 1,
+                    message: 'Opening parenthesis should be followed by one space.'
+                },
+                {
+                    column: 27,
+                    line: 1,
+                    message: 'Closing parenthesis should be preceded by one space.'
+                }
+            ];
 
             var options = {
                 style: 'one_space'


### PR DESCRIPTION
the linter was pitching a fit about array definition indentation when the array def contained multiple objects.

also separated the lint and config task deps for the test task, enforcing a linear and synchronous execution. was having an issue of the coverage task failing because of a syntax error before the lint task could tell me where it was.