### PR TITLE
Fix possible decimalZero regression with floats greater than 1

### DIFF
--- a/lib/linters/decimal_zero.js
+++ b/lib/linters/decimal_zero.js
@@ -33,7 +33,7 @@ module.exports = {
 
             switch (config.style) {
                 case 'leading':
-                    if (!/^-?(0\d*)\.(\d*[1-9])$/.test(number)) {
+                    if (!/^-?(\d+)\.(\d*[1-9])$/.test(number)) {
                         output.type = 'leading';
                     }
                     break;
@@ -43,7 +43,7 @@ module.exports = {
                     }
                     break;
                 case 'both':
-                    if (!/^-?(0\d*)\.(\d*0)$/.test(number)) {
+                    if (!/^-?(\d+)\.(\d*0)$/.test(number)) {
                         output.type = 'leading and trailing';
                     }
                     break;

--- a/test/specs/linters/decimal_zero.js
+++ b/test/specs/linters/decimal_zero.js
@@ -52,6 +52,17 @@ describe('lesshint', function () {
                 expect(result).to.be.undefined;
             });
 
+            it('should allow decimal number greater than 1 without leading zero', function () {
+                ast = parseAST('.foo { font-size: 1.25em; }')
+                        .first()
+                        .first('block')
+                        .first('declaration');
+
+                result = linter.lint(options, ast);
+
+                expect(result).to.be.undefined;
+            });
+
             it('should not allow number without leading decimal zero', function () {
                 expected = [{
                     column: 19,
@@ -171,6 +182,17 @@ describe('lesshint', function () {
 
             it('should allow "0.0"', function () {
                 ast = parseAST('.foo { font-size: 0.0em; }')
+                        .first()
+                        .first('block')
+                        .first('declaration');
+
+                result = linter.lint(options, ast);
+
+                expect(result).to.be.undefined;
+            });
+
+            it('should allow decimal number greater than 1 without leading zero', function () {
+                ast = parseAST('.foo { font-size: 1.250em; }')
                         .first()
                         .first('block')
                         .first('declaration');


### PR DESCRIPTION
I think I found a minor regression in the recent patch for `decimalZero`. 

The issues I found:
* Earlier `1.25` wouldn't be reported when `style` was `trailing` but now it was. 
* Earlier `1.250` wouldn't be reported when `style` was `both` but now it was. 

@CITguy Could you just take a look at this fix and see if it does what you expect?