### PR TITLE
Fix fragment identifier (#depthlevel)

### DIFF
--- a/lib/linters/README.md
+++ b/lib/linters/README.md
@@ -4,7 +4,7 @@
 * [borderZero](#borderzero)
 * [comment](#comment)
 * [decimalZero](#decimalzero)
-* [depthLevel](#depthLevel)
+* [depthLevel](#depthlevel)
 * [duplicateProperty](#duplicateproperty)
 * [emptyRule](#emptyrule)
 * [finalNewline](#finalnewline)


### PR DESCRIPTION
The fragment identifier for the **depthLevel** section should be `#depthlevel` (lowercase).