### PR TITLE
Fix gonazel-pe not being fetched when git protocol port is blocked

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "chalk": "^1.0.0",
     "commander": "^2.8.0",
     "exit": "^0.1.2",
-    "gonzales-pe": "git://github.com/gilt/gonzales-pe.git#dev",
+    "gonzales-pe": "gilt/gonzales-pe#dev",
     "lodash.findindex": "^4.0.1",
     "lodash.merge": "^4.0.1",
     "lodash.sortby": "^4.0.1",


### PR DESCRIPTION
- Provides a workaround within enterprises where the default git protocol port is blocked.
- Use github URL format in package.json instead of a git only URL. This prevents npm from failing when and rather use https ports instead of git protocol port (9418) id git global config are set via: `git config --global url."https://".insteadOf git://`