### PR TITLE
Strip trailing slashes from directory argument

### DIFF
--- a/lib/lesshint.js
+++ b/lib/lesshint.js
@@ -15,7 +15,7 @@ var Lesshint = function () {
 Lesshint.prototype.checkDirectory = function (checkPath) {
     return fs.listDir(checkPath).then(function (files) {
         files = files.map(function (file) {
-            var fullPath = checkPath + '/' + file;
+            var fullPath = path.join(checkPath, file);
 
             return fs.stat(fullPath).then(function (stats) {
                 if (stats.isDirectory()) {

--- a/test/specs/lesshint.js
+++ b/test/specs/lesshint.js
@@ -19,6 +19,17 @@ describe('lesshint', function () {
             });
         });
 
+        it('should strip trailing slashes from directory names', function () {
+            var testPath = path.dirname(__dirname) + '/data/files/sub/';
+            var lesshint = new Lesshint();
+
+            lesshint.configure();
+
+            return lesshint.checkDirectory(testPath).then(function (result) {
+                expect(result[0].fullPath).to.equal(testPath + 'file.less');
+            });
+        });
+
         it('should ignore dotfiles', function () {
             var testPath = path.dirname(__dirname) + '/data/ignored-files';
             var lesshint = new Lesshint();


### PR DESCRIPTION
-Fix case where report fullPath field would have multiple slashes
separating directories

ex. `lesshint src/` would produce reports with fullPaths like `src//foo/bar/baz.less`