### PR TITLE
2.0 propertyOrdering bugs

### DIFF
--- a/lib/linters/property_ordering.js
+++ b/lib/linters/property_ordering.js
@@ -25,7 +25,8 @@ module.exports = {
 
             property = child.prop;
 
-            if (!property) {
+            // Ignore declarations without a property and variables
+            if (!property || (property && /^@/.test(property))) {
                 return;
             }
 

--- a/lib/linters/property_ordering.js
+++ b/lib/linters/property_ordering.js
@@ -15,15 +15,15 @@ module.exports = {
             throw new Error('Invalid setting value for propertyOrdering: ' + config.style);
         }
 
-        node.walkDecls(function (declaration) {
+        node.each(function (child) {
             var currentProperty;
             var property;
 
-            if (results.length) {
+            if (child.type !== 'decl' || results.length) {
                 return;
             }
 
-            property = declaration.prop;
+            property = child.prop;
 
             if (!property) {
                 return;
@@ -34,8 +34,8 @@ module.exports = {
             // Check for proper ordering
             if (previousProp && previousProp.localeCompare(currentProperty) > 0) {
                 results = [{
-                    column: declaration.source.start.column,
-                    line: declaration.source.start.line,
+                    column: child.source.start.column,
+                    line: child.source.start.line,
                     message: self.message
                 }];
             }

--- a/test/specs/linters/property_ordering.js
+++ b/test/specs/linters/property_ordering.js
@@ -71,6 +71,28 @@ describe('lesshint', function () {
             });
         });
 
+        it('should check each rule on its own', function () {
+            var source = '';
+            var options = {
+                style: 'alpha'
+            };
+
+            source += '.form-group {';
+            source += '    margin-bottom: 0;';
+            source += '    .form-control {';
+            source += '        height: auto;';
+            source += '    }';
+            source += '}';
+
+            source += '.foo { margin-bottom: 0; }';
+
+            return spec.parse(source, function (ast) {
+                var result = spec.linter.lint(options, ast.root.first);
+
+                expect(result).to.be.undefined;
+            });
+        });
+
         it('should not try to check variables', function () {
             var source = '.foo { @var: auto; }';
             var options = {

--- a/test/specs/linters/property_ordering.js
+++ b/test/specs/linters/property_ordering.js
@@ -84,8 +84,6 @@ describe('lesshint', function () {
             source += '    }';
             source += '}';
 
-            source += '.foo { margin-bottom: 0; }';
-
             return spec.parse(source, function (ast) {
                 var result = spec.linter.lint(options, ast.root.first);
 

--- a/test/specs/linters/property_ordering.js
+++ b/test/specs/linters/property_ordering.js
@@ -94,20 +94,7 @@ describe('lesshint', function () {
         });
 
         it('should not try to check variables', function () {
-            var source = '.foo { @var: auto; }';
-            var options = {
-                style: 'alpha'
-            };
-
-            return spec.parse(source, function (ast) {
-                var result = spec.linter.lint(options, ast.root.first);
-
-                expect(result).to.be.undefined;
-            });
-        });
-
-        it('should not try to check variables', function () {
-            var source = '.foo { @var: auto; }';
+            var source = '.foo { @b: auto; @a: inherit; }';
             var options = {
                 style: 'alpha'
             };


### PR DESCRIPTION
This fixes two issues:
* It treated all the declarations in nested rules as one and thus complained about them. See #177.
* It would complain on variables that weren't alphabetically ordered.