### PR TITLE
fixes #130: spaceBetweenParens fails with mulitiline definitions

### DIFF
--- a/lib/linters/space_between_parens.js
+++ b/lib/linters/space_between_parens.js
@@ -40,6 +40,16 @@ module.exports = {
             prev = child.parent.nodes[index - 1];
             next = child.parent.nodes[index + 1];
 
+            // issue #130: newlines aren't accounted for. remove em cause we
+            // don't count em.
+            if (next && next.raws && next.raws.before) {
+                next.raws.before = next.raws.before.replace(/\n/g, '');
+            }
+
+            if (prev && prev.raws && prev.raws.after) {
+                prev.raws.after = prev.raws.after.replace(/\n/g, '');
+            }
+
             switch (config.style) {
                 case 'no_space':
                     if (child.value === '(' && (next.raws && next.raws.before)) {

--- a/test/specs/linters/space_between_parens.js
+++ b/test/specs/linters/space_between_parens.js
@@ -196,6 +196,16 @@ describe('lesshint', function () {
                 });
             });
 
+            it('should allow multiline mixins', function () {
+                var source = '.mixin(\n@a,\n@b\n) {\n \n}';
+
+                return spec.parse(source, function (ast) {
+                    var result = spec.linter.lint(options, ast.root.first);
+
+                    expect(result).to.be.undefined;
+                });
+            });
+
             it('should not allow one space after opening parenthesis in mixins', function () {
                 var source = '.mixin( @margin, @padding) {}';
                 var expected = [{
@@ -297,6 +307,16 @@ describe('lesshint', function () {
                     var result = spec.linter.lint(options, ast.root.first);
 
                     expect(result).to.deep.equal(expected);
+                });
+            });
+
+            it('should allow missing space before closing parenthesis in mixins', function () {
+                var source = '.mixin(@margin, @padding) {}';
+
+                return spec.parse(source, function (ast) {
+                    var result = spec.linter.lint(options, ast.root.first);
+
+                    expect(result).to.be.undefined;
                 });
             });
         }); // "no_space"
@@ -464,6 +484,16 @@ describe('lesshint', function () {
 
             it('should allow one space after opening parenthesis and before closing parenthesis in mixins', function () {
                 var source = '.mixin( @margin, @padding ) {}';
+
+                return spec.parse(source, function (ast) {
+                    var result = spec.linter.lint(options, ast.root.first);
+
+                    expect(result).to.be.undefined;
+                });
+            });
+
+            it('should allow one space before closing paren in multiline mixins', function () {
+                var source = '.mixin( \n@a,\n@b\n ) {\n \n}';
 
                 return spec.parse(source, function (ast) {
                     var result = spec.linter.lint(options, ast.root.first);


### PR DESCRIPTION
just stripping the newline characters from raws for now. we can get fancier if we decide to implement something more intelligent. this should cover most cases in the meantime.