### PR TITLE
fixes #119: adds allowNewline option to spaceAroundComma

### DIFF
--- a/lib/config/defaults.json
+++ b/lib/config/defaults.json
@@ -132,6 +132,7 @@
     },
 
     "spaceAroundComma": {
+        "allowNewline": false,
         "enabled": true,
         "style": "after"
     },

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -125,8 +125,6 @@ var runChecks = function (ast, fullPath, lines, config) {
         linters.forEach(function (linter) {
             var options = config[linter.name];
             var lint;
-            var matches;
-            var pseudoParams;
 
             // Bail if the linter isn't wanted
             if (!options || (options && !options.enabled)) {
@@ -142,14 +140,15 @@ var runChecks = function (ast, fullPath, lines, config) {
             // an actual Mixin or AtRule, and its selector contains a pseudo
             // class or selector, then clean up the raws and params properties.
             // tracking: https://github.com/webschik/postcss-less/issues/56
+            // TODO: remove this when issue resolved
             if (node.params && rPseudo.test(node.selector)) {
-              delete node.params;
+                delete node.params;
 
-              // this just started showing up in postcss-less@0.14.0. not sure
-              // if it's sticking around, but making sure we're thorough.
-              if (node.raws.params) {
-                delete node.raws.params;
-              }
+                // this just started showing up in postcss-less@0.14.0. not sure
+                // if it's sticking around, but making sure we're thorough.
+                if (node.raws.params) {
+                    delete node.raws.params;
+                }
             }
 
             lint = linter.lint.call(linter, options, node);

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -96,6 +96,9 @@ var runChecks = function (ast, fullPath, lines, config) {
     var inlineOptions;
     var linters;
 
+    // tests selectors for pseudo classes/selectors. eg. :not(), :active
+    var rPseudo = /::?[^ ,:.]+/g;
+
     // Freeze the AST so linters won't accidentally change it
     Object.freeze(ast);
 
@@ -122,6 +125,8 @@ var runChecks = function (ast, fullPath, lines, config) {
         linters.forEach(function (linter) {
             var options = config[linter.name];
             var lint;
+            var matches;
+            var pseudoParams;
 
             // Bail if the linter isn't wanted
             if (!options || (options && !options.enabled)) {
@@ -133,7 +138,22 @@ var runChecks = function (ast, fullPath, lines, config) {
                 return;
             }
 
+            // if we're dealing with a regular Rule (or other) node, which isn't
+            // an actual Mixin or AtRule, and its selector contains a pseudo
+            // class or selector, then clean up the raws and params properties.
+            // tracking: https://github.com/webschik/postcss-less/issues/56
+            if (node.params && rPseudo.test(node.selector)) {
+              delete node.params;
+
+              // this just started showing up in postcss-less@0.14.0. not sure
+              // if it's sticking around, but making sure we're thorough.
+              if (node.raws.params) {
+                delete node.raws.params;
+              }
+            }
+
             lint = linter.lint.call(linter, options, node);
+
             if (lint) {
                 if (!Array.isArray(lint)) {
                     throw new Error('Linter ' + linter.name + ' must return an array.');

--- a/lib/linters/README.md
+++ b/lib/linters/README.md
@@ -606,9 +606,10 @@ Option     | Description
 ## spaceAroundComma
 Defines how commas in functions, mixins, etc. should be formatted by a space to aid readability.
 
-Option     | Description
----------- | ----------
-`style`    | `after` (**default**), `before`, `both`, `none`
+Option          | Description
+----------------| ----------
+`allowNewline`  | `false` (**default**), `boolean`
+`style`         | `after` (**default**), `before`, `both`, `none`
 
 ### after
 ```less
@@ -635,6 +636,16 @@ Option     | Description
 ```less
 .foo {
     color: rgb(255,255,255);
+}
+```
+
+### allowNewline : true
+```less
+.foo {
+  font:
+    14px,
+    Roboto,
+    #000;
 }
 ```
 

--- a/lib/linters/important_rule.js
+++ b/lib/linters/important_rule.js
@@ -9,10 +9,6 @@ module.exports = {
         var pos = 1;
 
         if (node.important) {
-            if (node.raws.important) {
-                pos = node.raws.important.indexOf('!');
-            }
-
             return [{
                 column: node.source.start.column + node.prop.length + node.raws.between.length + node.value.length + pos,
                 line: node.source.start.line,

--- a/lib/linters/qualifying_element.js
+++ b/lib/linters/qualifying_element.js
@@ -26,7 +26,7 @@ module.exports = {
             }
 
             result.endsWith = selector.last.type;
-
+            console.log(selector.nodes);
             if (!result.hasTag) {
                 selector.nodes.forEach(function (element) {
                     if (element.type === 'tag') {

--- a/lib/linters/space_around_comma.js
+++ b/lib/linters/space_around_comma.js
@@ -36,8 +36,22 @@ module.exports = {
             index = child.parent.index(child);
             next = child.parent.nodes[index + 1];
 
+            // the user has opted to ignore decls, etc where newlines are used
+            // to separate comma-delimited lists.
+            if (config.allowNewline) {
+                if (config.style === 'after' && /\n/g.test(next.raws.before)) {
+                    return;
+                }
+
+                if (/\n/g.test(child.raws.after)) {
+                    return;
+                }
+            }
+
             // newlines aren't accounted for. remove em cause we don't count
-            // em. (#209)
+            // em. (#209) users can choose to turn off trailing spaces and choose
+            // to have trailing whitespace after a comma, but before a newline.
+            // it's silly, but it's an available option.
             if (next && next.raws && next.raws.before) {
                 next.raws.before = next.raws.before.replace(/\n/g, '');
             }

--- a/lib/linters/space_around_comma.js
+++ b/lib/linters/space_around_comma.js
@@ -43,7 +43,7 @@ module.exports = {
                     return;
                 }
 
-                if (/\n/g.test(child.raws.after)) {
+                if (/\n/g.test(child.raws.before)) {
                     return;
                 }
             }
@@ -56,8 +56,8 @@ module.exports = {
                 next.raws.before = next.raws.before.replace(/\n/g, '');
             }
 
-            if (child && child.raws && child.raws.after) {
-                child.raws.after = child.raws.after.replace(/\n/g, '');
+            if (child && child.raws && child.raws.before) {
+                child.raws.before = child.raws.before.replace(/\n/g, '');
             }
 
             switch (config.style) {

--- a/test/specs/linter.js
+++ b/test/specs/linter.js
@@ -366,6 +366,16 @@ describe('linter', function () {
             expect(result).to.deep.equal(expected);
         });
 
+        it('should not report comma spaces for selectors that have pseudos', function () {
+            var source = '.foo,\n.bar:not(.foo){}';
+            var path = 'test.less';
+            var result;
+
+            result = linter.lint(source, path, {});
+
+            expect(result).to.have.length(0);
+        });
+
         it('should load a custom linter (as a require path)', function () {
             var source = '// boo!\n';
             var path = 'test.less';

--- a/test/specs/linters/attribute_quotes.js
+++ b/test/specs/linters/attribute_quotes.js
@@ -13,6 +13,16 @@ describe('lesshint', function () {
             });
         });
 
+        it('should bail if the node has no selector', function () {
+            var source = "input[type='text'] { width: 0; }";
+
+            return spec.parse(source, function (ast) {
+                var result = spec.linter.lint({}, ast.root.first.first);
+
+                expect(result).to.be.undefined;
+            });
+        });
+
         it('should allow single quotes', function () {
             var source = "input[type='text'] {}";
 

--- a/test/specs/linters/space_around_comma.js
+++ b/test/specs/linters/space_around_comma.js
@@ -85,6 +85,41 @@ describe('lesshint', function () {
                     expect(result).to.deep.equal(expected);
                 });
             });
+
+            it('should not allow multiline comma lists when allowNewline is false', function () {
+                var source = 'font: 14px,\n    Roboto,\n    #000000;';
+                var expected = [
+                    {
+                        column: 11,
+                        message: 'Commas should be followed by one space.'
+                    },
+                    {
+                        column: 17,
+                        message: 'Commas should be followed by one space.'
+                    }
+                ];
+
+                options.allowNewline = false;
+
+                return spec.parse(source, function (ast) {
+                    var result = spec.linter.lint(options, ast.root.first);
+
+                    expect(result).to.deep.equal(expected);
+                });
+            });
+
+            it('should  allow multiline comma lists when allowNewline is true', function () {
+                var source = 'font: 14px,\n    Roboto,\n    #000000;';
+
+                options.allowNewline = true;
+
+                return spec.parse(source, function (ast) {
+                    var result = spec.linter.lint(options, ast.root.first);
+
+                    expect(result).to.be.undefined;
+                });
+            });
+
         }); // "after"
 
         describe('when "style" is "before"', function () {

--- a/test/specs/linters/space_around_comma.js
+++ b/test/specs/linters/space_around_comma.js
@@ -72,6 +72,16 @@ describe('lesshint', function () {
                 });
             });
 
+            it('should account for multiline rules with commas containing pseudo classes', function () {
+                var source = '.test1,\n.test2:not(.test3),\n.test3:not(.test2) {\n    width: 100%;\n}';
+
+                return spec.parse(source, function (ast) {
+                    var result = spec.linter.lint(options, ast.root.first);
+
+                    expect(result).to.be.undefined;
+                });
+            });
+
             it('should not allow missing space after comma in mixins', function () {
                 var source = '.mixin(@margin,@padding) {}';
                 var expected = [{
@@ -108,7 +118,7 @@ describe('lesshint', function () {
                 });
             });
 
-            it('should  allow multiline comma lists when allowNewline is true', function () {
+            it('should allow multiline comma lists when allowNewline is true', function () {
                 var source = 'font: 14px,\n    Roboto,\n    #000000;';
 
                 options.allowNewline = true;
@@ -180,6 +190,18 @@ describe('lesshint', function () {
                     var result = spec.linter.lint(options, ast.root.first);
 
                     expect(result).to.deep.equal(expected);
+                });
+            });
+
+            it('should allow multiline comma lists when allowNewline is true', function () {
+                var source = 'font: 14px\n,    Roboto\n,    #000000;';
+
+                options.allowNewline = true;
+
+                return spec.parse(source, function (ast) {
+                    var result = spec.linter.lint(options, ast.root.first);
+
+                    expect(result).to.be.undefined;
                 });
             });
         }); // "before"

--- a/test/specs/linters/url_quotes.js
+++ b/test/specs/linters/url_quotes.js
@@ -21,8 +21,28 @@ describe('lesshint', function () {
             });
         });
 
+        it('should not check nodes without params', function () {
+            var source = '.foo { @bar }';
+
+            return spec.parse(source, function (ast) {
+                var result = spec.linter.lint({}, ast.root.first.first);
+
+                expect(result).to.be.undefined;
+            });
+        });
+
+        it('should not check nodes without values', function () {
+            var source = '.foo { @bar() }';
+
+            return spec.parse(source, function (ast) {
+                var result = spec.linter.lint({}, ast.root.first.first);
+
+                expect(result).to.be.undefined;
+            });
+        });
+
         it('should allow single quotes', function () {
-            var source = ".foo { background-image: url('img/image.jpg'); }";
+            var source = '.foo { background-image: url(\'img/image.jpg\'); }';
 
             return spec.parse(source, function (ast) {
                 var result = spec.linter.lint({}, ast.root.first.first);

--- a/test/specs/util.js
+++ b/test/specs/util.js
@@ -8,6 +8,9 @@ module.exports = {
         var filename = '../../lib/linters/';
         var linter;
 
+        // tests selectors for pseudo classes/selectors. eg. :not(), :active
+        var rPseudo = /::?[^ ,:.]+/g;
+
         // slightly evil, but it's OK since this is just for specs
         // nodejs caches module.parent as the first module to require it,
         // which in the case of specs, is mocha.
@@ -27,6 +30,25 @@ module.exports = {
             parser: getParser,
             parse: function (source, callback) {
                 return getParser(source).then(function (ast) {
+                    // if we're dealing with a regular Rule (or other) node, which isn't
+                    // an actual Mixin or AtRule, and its selector contains a pseudo
+                    // class or selector, then clean up the raws and params properties.
+                    // if we don't have this here, then the tests never get the same
+                    // modified nodes.
+                    // tracking: https://github.com/webschik/postcss-less/issues/56
+                    // TODO: remove this when issue resolved
+                    ast.root.walk(function (node) {
+                        if (node.params && rPseudo.test(node.selector)) {
+                            delete node.params;
+
+                            // this just started showing up in postcss-less@0.14.0. not sure
+                            // if it's sticking around, but making sure we're thorough.
+                            if (node.raws.params) {
+                                delete node.raws.params;
+                            }
+                        }
+                    });
+
                     callback && callback(ast);
                 });
             }


### PR DESCRIPTION
This is my proposal for the spaceAroundComma fix when newlines are used to separate comma-delimited lists. `allowNewline` set to `true` will skip any verification of space around a comma if a newline is detected, based on the `style` option chosen. 