### PR TITLE
fixes #236: import options breaking importPath linter

### DIFF
--- a/lib/linters/import_path.js
+++ b/lib/linters/import_path.js
@@ -15,15 +15,21 @@ module.exports = {
 
     lint: function importPathLinter (config, node) {
         var results = [];
+        var importOptsRx = /(\s+)?\((\s+)?(reference|inline|less|css|once|multiple|optional)(\s+)?\)(\s+)?/gi;
         var value;
         var file;
         var ast;
+        var params;
 
         if (node.name !== 'import') {
             return;
         }
 
-        ast = parser(node.params).parse();
+        // temporary fix for https://github.com/lesshint/lesshint/issues/236
+        // TODO: postcss-less really needs to be fixed to make this proper.
+        params = node.params.replace(importOptsRx, '');
+
+        ast = parser(params).parse();
         value = ast.first.first;
 
         // Extract the value if it's a url() call

--- a/test/specs/linters/import_path.js
+++ b/test/specs/linters/import_path.js
@@ -300,4 +300,89 @@ describe('lesshint', function () {
             });
         });
     });
+
+    describe('#importPath() with Import Option', function () {
+
+        it('should allow filename without extension when "filenameExtension" is "false"', function () {
+            var source = '@import (css) "foo";';
+            var options = {
+                filenameExtension: false,
+                exclude: []
+            };
+
+            return spec.parse(source, function (ast) {
+                var result = spec.linter.lint(options, ast.root.first);
+
+                expect(result).to.be.undefined;
+            });
+        });
+
+        it('should allow filename with .css extension when "filenameExtension" is "false"', function () {
+            var source = '@import (inline) "foo.css";';
+            var options = {
+                filenameExtension: false,
+                exclude: []
+            };
+
+            return spec.parse(source, function (ast) {
+                var result = spec.linter.lint(options, ast.root.first);
+
+                expect(result).to.be.undefined;
+            });
+        });
+
+        it('should not allow filename with extension when "filenameExtension" is "false"', function () {
+            var source = '@import (inline) "foo.less";';
+            var expected = [{
+                column: 9,
+                line: 1,
+                message: 'Imported file, "foo.less" should not include the file extension.'
+            }];
+
+            var options = {
+                filenameExtension: false,
+                exclude: []
+            };
+
+            return spec.parse(source, function (ast) {
+                var result = spec.linter.lint(options, ast.root.first);
+
+                expect(result).to.deep.equal(expected);
+            });
+        });
+
+        it('should allow filename with extension when "filenameExtension" is "true"', function () {
+            var source = '@import (inline) "foo.less";';
+            var options = {
+                filenameExtension: true,
+                exclude: []
+            };
+
+            return spec.parse(source, function (ast) {
+                var result = spec.linter.lint(options, ast.root.first);
+
+                expect(result).to.be.undefined;
+            });
+        });
+
+        it('should not allow filename without extension when "filenameExtension" is "true"', function () {
+            var source = '@import (inline) "foo";';
+            var expected = [{
+                column: 9,
+                line: 1,
+                message: 'Imported file, "foo" should include the file extension.'
+            }];
+
+            var options = {
+                filenameExtension: true,
+                exclude: []
+            };
+
+            return spec.parse(source, function (ast) {
+                var result = spec.linter.lint(options, ast.root.first);
+
+                expect(result).to.deep.equal(expected);
+            });
+        });
+    });
 });


### PR DESCRIPTION
This is just a simple regex replace on the `params` node property. It should hold us over until https://github.com/webschik/postcss-less/issues/57 is fixed. Not an ideal fix by any means, but the likelihood of the import options list growing faster than we can update this regex is slim to none.

Added a few dupe tests with an import option just to make sure it doesn't break moving forward. 