### PR TITLE
Failing linter tests

### DIFF
--- a/test/data/config/failingLinter.json
+++ b/test/data/config/failingLinter.json
@@ -1,0 +1,3 @@
+{
+    "linters": ["../test/plugins/failingLinter"]
+}

--- a/test/plugins/failingLinter.js
+++ b/test/plugins/failingLinter.js
@@ -1,0 +1,3 @@
+'use strict';
+
+throw new Error('Fail!');

--- a/test/specs/cli.js
+++ b/test/specs/cli.js
@@ -191,6 +191,40 @@ describe('cli', function () {
         });
     });
 
+    it('should fail loading linters if a command-line linter errors', function () {
+        var result;
+
+        sinon.spy(console, 'log');
+
+        result = cli({
+            args: [path.dirname(__dirname) + '/data/files/file.less'],
+            config: path.resolve(process.cwd() + '/test/data/config/linters.json'),
+            linters: ['../test/plugins/failingLinter']
+        });
+
+        return result.fail(function (status) {
+            console.log.restore();
+            expect(status).to.equal(70);
+        });
+    });
+
+    it('should fail loading linters if a config file linter errors', function () {
+        var result;
+
+        sinon.spy(console, 'log');
+
+        result = cli({
+            args: [path.dirname(__dirname) + '/data/files/file.less'],
+            config: path.resolve(process.cwd() + '/test/data/config/linters-failing.json'),
+            linters: ['../test/plugins/sampleLinter']
+        });
+
+        return result.fail(function (status) {
+            console.log.restore();
+            expect(status).to.equal(78);
+        });
+    });
+
     it('should exit without errors when passed a built-in reporter name', function () {
         var result;
 


### PR DESCRIPTION
Tests that a CLI fail and a config fail both cause the appropriate errors.

Fixes #205.