### PR TITLE
Space before brace new line and whitespace

### DIFF
--- a/lib/linters/space_before_brace.js
+++ b/lib/linters/space_before_brace.js
@@ -12,9 +12,9 @@ module.exports = {
     lint: function spaceBeforeBraceLinter (config, node) {
         var column;
         var styles = {
-            'new_line': /^\n$/,
+            'new_line': /^\n *\t*$/,
             'no_space': /^$/,
-            'one_space': /^\s$/
+            'one_space': /^ $/
         };
 
         if (config.style && !styles[config.style]) {

--- a/test/specs/linters/space_before_brace.js
+++ b/test/specs/linters/space_before_brace.js
@@ -185,8 +185,46 @@ describe('lesshint', function () {
             });
         });
 
-        it('should not allow multiple spaces when multiple simple selectors are used and "style" is "one_space"', function () {
-            var source = '.foo, .bar  {}';
+        it('should not allow multiple spaces when "style" is "one_space"', function () {
+            var source = '.foo  {}';
+            var expected = [{
+                column: 5,
+                line: 1,
+                message: 'Opening curly brace should be preceded by one space.'
+            }];
+
+            var options = {
+                style: 'one_space'
+            };
+
+            return spec.parse(source, function (ast) {
+                var result = spec.linter.lint(options, ast.root.first);
+
+                expect(result).to.deep.equal(expected);
+            });
+        });
+
+        it('should not allow new line when "style" is "one_space"', function () {
+            var source = '.foo, .bar\n{}';
+            var expected = [{
+                column: 11,
+                line: 1,
+                message: 'Opening curly brace should be preceded by one space.'
+            }];
+
+            var options = {
+                style: 'one_space'
+            };
+
+            return spec.parse(source, function (ast) {
+                var result = spec.linter.lint(options, ast.root.first);
+
+                expect(result).to.deep.equal(expected);
+            });
+        });
+
+        it('should not allow tab when "style" is "one_space"', function () {
+            var source = '.foo, .bar\t{}';
             var expected = [{
                 column: 11,
                 line: 1,
@@ -219,6 +257,32 @@ describe('lesshint', function () {
 
         it('should allow one new line when a selector group is used and "style" is "new_line"', function () {
             var source = '.foo, .bar\n{}';
+            var options = {
+                style: 'new_line'
+            };
+
+            return spec.parse(source, function (ast) {
+                var result = spec.linter.lint(options, ast.root.first);
+
+                expect(result).to.be.undefined;
+            });
+        });
+
+        it('should allow one new line followed by spaces when "style" is "new_line"', function () {
+            var source = '.foo\n       {}';
+            var options = {
+                style: 'new_line'
+            };
+
+            return spec.parse(source, function (ast) {
+                var result = spec.linter.lint(options, ast.root.first);
+
+                expect(result).to.be.undefined;
+            });
+        });
+
+        it('should allow one new line followed by tabs when "style" is "new_line"', function () {
+            var source = '.foo\n\t\t{}';
             var options = {
                 style: 'new_line'
             };

--- a/test/specs/linters/space_before_brace.js
+++ b/test/specs/linters/space_before_brace.js
@@ -242,6 +242,25 @@ describe('lesshint', function () {
             });
         });
 
+        it('should not allow multiple spaces when multiple simple selectors are used and "style" is "one_space"', function () {
+            var source = '.foo, .bar  {}';
+            var expected = [{
+                column: 11,
+                line: 1,
+                message: 'Opening curly brace should be preceded by one space.'
+            }];
+
+            var options = {
+                style: 'one_space'
+            };
+
+            return spec.parse(source, function (ast) {
+                var result = spec.linter.lint(options, ast.root.first);
+
+                expect(result).to.deep.equal(expected);
+            });
+        });
+
         it('should allow one new line when "style" is "new_line"', function () {
             var source = '.foo\n{}';
             var options = {


### PR DESCRIPTION
This fixes #244 where setting "space before brace" to "new_line" did not allow you to indent the code.

It also fixes another issue in the "one_space" reg ex which used \s instead of space literal. \s does not mean space it means all whitespace characters so it would also pick up new lines (providing you use Unix style of just LF and not windows which uses two characters) and tabs.

Test have been provided and all pass.