### PR TITLE
Add support for LESS merge feature

### DIFF
--- a/lib/linters/duplicate_property.js
+++ b/lib/linters/duplicate_property.js
@@ -19,7 +19,7 @@ module.exports = {
                 return true;
             }
 
-            if (properties.indexOf(decl.prop) >= 0) {
+            if (!decl.prop.match(/\+\_?$/) && properties.indexOf(decl.prop) >= 0) {
                 results.push({
                     message: util.format(self.message, decl.prop),
                     column: decl.source.start.column,

--- a/test/specs/linters/duplicate_property.js
+++ b/test/specs/linters/duplicate_property.js
@@ -103,7 +103,7 @@ describe('lesshint', function () {
                 expect(result).to.be.undefined;
             });
         });
-        
+
         it('should ignore comma merge properties', function () {
             var source = '.foo { box-shadow+: 0 0 10px #555; box-shadow+: inset 0 0 5px #222; }';
             var options = {
@@ -130,6 +130,5 @@ describe('lesshint', function () {
             });
         });
 
-        
     });
 });

--- a/test/specs/linters/duplicate_property.js
+++ b/test/specs/linters/duplicate_property.js
@@ -103,5 +103,33 @@ describe('lesshint', function () {
                 expect(result).to.be.undefined;
             });
         });
+        
+        it('should ignore comma merge properties', function () {
+            var source = '.foo { box-shadow+: 0 0 10px #555; box-shadow+: inset 0 0 5px #222; }';
+            var options = {
+                exclude: []
+            };
+
+            return spec.parse(source, function (ast) {
+                var result = spec.linter.lint(options, ast.root.first);
+
+                expect(result).to.be.undefined;
+            });
+        });
+
+        it('should ignore space merge properties', function () {
+            var source = '.foo { transform+_: scale(2); transform+_: rotate(15deg); }';
+            var options = {
+                exclude: []
+            };
+
+            return spec.parse(source, function (ast) {
+                var result = spec.linter.lint(options, ast.root.first);
+
+                expect(result).to.be.undefined;
+            });
+        });
+
+        
     });
 });


### PR DESCRIPTION
DuplicateProperty config should ingnore duplicate property ending with a "+" or "+_". This is a LESS merge feature. See: http://lesscss.org/features/#merge-feature