### PR TITLE
Report invalid inline options

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -57,7 +57,7 @@ var parseRules = function (node) {
     try {
         rules = JSON.parse('{' + rules + '}');
     } catch (e) {
-        throw new Error('Invalid inline option on line ' + node.start.line);
+        throw new Error('Invalid inline option on line ' + node.source.start.line);
     }
 
     // If it's only shorthand enabled or disabled, account for that

--- a/test/data/inline-options/options-invalid.less
+++ b/test/data/inline-options/options-invalid.less
@@ -1,0 +1,1 @@
+// lesshint fnord

--- a/test/specs/linter.js
+++ b/test/specs/linter.js
@@ -366,6 +366,14 @@ describe('linter', function () {
             expect(result).to.deep.equal(expected);
         });
 
+        it('should report invalid inline options', function () {
+            var source = fs.readFileSync(path.resolve(process.cwd(), './test/data/inline-options/options-invalid.less'), 'utf8');
+
+            expect(function () {
+                linter.lint(source, 'options-invalid.less', {});
+            }).to.throw('Invalid inline option on line 1');
+        });
+
         it('should not report comma spaces for selectors that have pseudos', function () {
             var source = '.foo,\n.bar:not(.foo){}';
             var path = 'test.less';


### PR DESCRIPTION
As of 2.1.1 an invalid inline option, (say, `// lesshint fnord`) will be reported unhelpfully by lesshint as `TypeError: Cannot read property 'line' of undefined`. This fixes the Error construction in parseRules to report the problem more clearly.

Incidentally, it seems to my amateur eye that it wouldn't be terribly difficult to report this inline with other errors, the same way CSS parse errors are handled. I could take a crack at that too, if it seems like a useful feature.