### PR TITLE
Account for trailing whitespace in newlineAfterBlock

### DIFF
--- a/lib/linters/newline_after_block.js
+++ b/lib/linters/newline_after_block.js
@@ -6,6 +6,7 @@ module.exports = {
     message: 'All blocks should be followed by a new line.',
 
     lint: function newlineAfterBlockLinter (config, node) {
+        var regexp = /\n[ \t]*\n?/;
         var parent = node.parent;
         var prev;
 
@@ -35,12 +36,12 @@ module.exports = {
          * unless it's the first comment of a block.
          */
         if (prev.type === 'comment') {
-            if (Object.is(prev, parent.first) || prev.raws.before.indexOf('\n\n') !== -1) {
+            if (Object.is(prev, parent.first) || !regexp.test(prev.raws.before)) {
                 return;
             }
         }
 
-        if (node.raws.before.indexOf('\n\n') === -1) {
+        if (!regexp.test(node.raws.before)) {
             return [{
                 message: this.message
             }];

--- a/lib/linters/newline_after_block.js
+++ b/lib/linters/newline_after_block.js
@@ -36,7 +36,7 @@ module.exports = {
          * unless it's the first comment of a block.
          */
         if (prev.type === 'comment') {
-            if (Object.is(prev, parent.first) || !regexp.test(prev.raws.before)) {
+            if (Object.is(prev, parent.first) || regexp.test(prev.raws.before)) {
                 return;
             }
         }

--- a/test/specs/linters/newline_after_block.js
+++ b/test/specs/linters/newline_after_block.js
@@ -135,5 +135,24 @@ describe('lesshint', function () {
                 expect(result).to.be.undefined;
             });
         });
+
+        it('should not report nested blocks with a preceding new line containing other white space', function () {
+            var source = '';
+
+            source += '.foo {';
+            source += '    color: red;';
+            source += '\n \t\n';
+            source += '    .bar {';
+            source += '        color: red;';
+            source += '    }';
+            source += '\n';
+            source += '}';
+
+            return spec.parse(source, function (ast) {
+                var result = spec.linter.lint({}, ast.root.last);
+
+                expect(result).to.be.undefined;
+            });
+        });
     });
 });


### PR DESCRIPTION
Allow trailing whitespace to be present on the empty line. This will hopefully fix #245.