### PR TITLE
Added a shorthand `true` for `{ enabled: true }`

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -107,7 +107,7 @@ var runChecks = function (ast, fullPath, lines, config) {
             var lint;
 
             // Bail if the linter isn't wanted
-            if (!options || (options && !options.enabled)) {
+            if (!options || (options && options !== true && !options.enabled)) {
                 return;
             }
 

--- a/test/specs/linter.js
+++ b/test/specs/linter.js
@@ -134,9 +134,7 @@ describe('linter', function () {
             ];
 
             var config = {
-                attributeQuotes: {
-                    enabled: true
-                },
+                attributeQuotes: true,
                 duplicateProperty: {
                     enabled: true,
                     exclude: []
@@ -193,9 +191,7 @@ describe('linter', function () {
             var result;
 
             var config = {
-                stringQuotes: {
-                    enabled: true
-                }
+                stringQuotes: true
             };
 
             result = linter.lint(source, path, config);
@@ -249,9 +245,7 @@ describe('linter', function () {
             }];
 
             var config = {
-                emptyRule: {
-                    enabled: true
-                },
+                emptyRule: true,
                 spaceAfterPropertyColon: {
                     enabled: true,
                     style: 'one_space'
@@ -283,9 +277,7 @@ describe('linter', function () {
             }];
 
             var config = {
-                emptyRule: {
-                    enabled: true
-                },
+                emptyRule: true,
                 spaceAfterPropertyColon: {
                     enabled: true,
                     style: 'one_space'
@@ -391,9 +383,7 @@ describe('linter', function () {
 
             var config = {
                 linters: ['../test/plugins/sampleLinter'],
-                sample: {
-                    enabled: true
-                }
+                sample: true
             };
 
             var expected = [{
@@ -419,9 +409,7 @@ describe('linter', function () {
 
             var config = {
                 linters: [require('../plugins/sampleLinter')],
-                sample: {
-                    enabled: true
-                }
+                sample: true
             };
 
             var expected = [{


### PR DESCRIPTION
Fixes #272.

Rules can just say they're `true` rather than the full `{ enabled: true
}`.