### PR TITLE
Add a max-warnings cli flag

### DIFF
--- a/bin/lesshint
+++ b/bin/lesshint
@@ -19,6 +19,7 @@ program
     .option('-e, --exclude [pattern]', 'path pattern to exclude')
     .option('-l --linters [linters]', 'paths to custom linters')
     .option('-r, --reporter [reporter]', 'reporter to use (<PATH>|stylish), defaults to "stylish"')
+    .option('-x, --max-warnings [int]', 'Number of warnings to trigger nonzero exit code, defaults to 0')
     .parse(process.argv);
 
 cli(program);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -61,7 +61,9 @@ module.exports = function (program) {
     promises = program.args.map(lesshint.checkPath, lesshint);
     Vow.all(promises).then(function (results) {
         var hasError;
+        var maxWarnings;
         var reporter;
+        var warnings;
 
         results = [].concat.apply([], results);
 
@@ -86,7 +88,22 @@ module.exports = function (program) {
         if (hasError) {
             exitDefer.reject(EXIT_CODES.ERROR);
         } else {
-            exitDefer.reject(EXIT_CODES.WARNING);
+            maxWarnings = parseInt(program.maxWarnings, 10) || 0;
+
+            if (maxWarnings === -1) {
+                exitDefer.resolve(EXIT_CODES.OK);
+                return;
+            }
+
+            warnings = results.reduce(function (sum, result) {
+                return sum + (result.severity === 'warning' ? 1 : 0);
+            }, 0);
+
+            if (warnings > maxWarnings) {
+                exitDefer.reject(EXIT_CODES.WARNING);
+            } else {
+                exitDefer.resolve(EXIT_CODES.OK);
+            }
         }
     }).fail(function (error) {
         console.error('An unknown error occurred when checking "%s", please file an issue with this info:', error.lesshintFile);

--- a/test/data/config/three-warns.json
+++ b/test/data/config/three-warns.json
@@ -1,0 +1,16 @@
+{
+    "spaceAfterPropertyColon": {
+        "enabled": true,
+        "style": "no_space"
+    },
+
+    "spaceBeforeBrace": {
+        "enabled": true,
+        "style": "new_line"
+    },
+
+    "spaceAfterPropertyValue": {
+        "enabled": true,
+        "style": "one_space"
+    }
+}

--- a/test/data/config/two-warns.json
+++ b/test/data/config/two-warns.json
@@ -1,0 +1,11 @@
+{
+    "spaceAfterPropertyColon": {
+        "enabled": true,
+        "style": "no_space"
+    },
+
+    "spaceBeforeBrace": {
+        "enabled": true,
+        "style": "new_line"
+    }
+}

--- a/test/specs/cli.js
+++ b/test/specs/cli.js
@@ -77,6 +77,86 @@ describe('cli', function () {
         });
     });
 
+    it('should exit with a non-zero status code when lint warnings pass `--max-warnings`', function () {
+        var result;
+
+        result = cli({
+            args: [
+                path.dirname(__dirname) + '/data/files/file.less',
+            ],
+            config: path.resolve(process.cwd() + '/lib/config/defaults.json'),
+            maxWarnings: '0',
+        });
+
+        return result.fail(function (status) {
+            expect(status).to.equal(1);
+        });
+    });
+
+    it('should exit with a non-zero status code with three warings and `--max-warnings 2`', function () {
+        var result;
+
+        result = cli({
+            args: [
+                path.dirname(__dirname) + '/data/files/file.less',
+            ],
+            config: path.resolve(process.cwd() + '/test/data/config/three-warns.json'),
+            maxWarnings: '2',
+        });
+
+        return result.fail(function (status) {
+            expect(status).to.equal(1);
+        });
+    });
+
+    it('should exit with zero status code with 2 warings and `--max-warnings 2`', function () {
+        var result;
+
+        result = cli({
+            args: [
+                path.dirname(__dirname) + '/data/files/file.less',
+            ],
+            config: path.resolve(process.cwd() + '/test/data/config/two-warns.json'),
+            maxWarnings: '2',
+        });
+
+        return result.then(function (status) {
+            expect(status).to.equal(0);
+        });
+    });
+
+    it('should exit with a zero status code when lint warnings do not pass `--max-warnings`', function () {
+        var result;
+
+        result = cli({
+            args: [
+                path.dirname(__dirname) + '/data/files/file.less',
+            ],
+            config: path.resolve(process.cwd() + '/lib/config/defaults.json'),
+            maxWarnings: '999',
+        });
+
+        return result.then(function (status) {
+            expect(status).to.equal(0);
+        });
+    });
+
+    it('should exit with a zero status code with `--max-warnings -1` even if lint has warings', function () {
+        var result;
+
+        result = cli({
+            args: [
+                path.dirname(__dirname) + '/data/files/file.less',
+            ],
+            config: path.resolve(process.cwd() + '/lib/config/defaults.json'),
+            maxWarnings: '-1',
+        });
+
+        return result.then(function (status) {
+            expect(status).to.equal(0);
+        });
+    });
+
     it('should exit with a non-zero status code when no files were passed', function () {
         var result;
 


### PR DESCRIPTION
Where number below `max-warnings` result in a zero exit code. This is
desirable for projects that allow a certain amount of warnings to pass
the build system, and the build system that relies on a zero exit code
for the build to pass.

We default to 0, for backwards compatibility. A max warning of -1 will
allow any number of warnings to pass.