### PR TITLE
Allow reporters to be objects, not just file paths

### DIFF
--- a/lib/lesshint.js
+++ b/lib/lesshint.js
@@ -127,6 +127,11 @@ Lesshint.prototype.getReporter = function (reporter) {
         return require(reporterPath);
     }
 
+    // Object with .report as a method: return it directly
+    if (reporter.constructor !== 'string' && reporter.report) {
+        return reporter;
+    }
+
     // Try to find it somewhere on disk
     try {
         reporterPath = path.resolve(process.cwd(), reporter);

--- a/test/specs/cli.js
+++ b/test/specs/cli.js
@@ -251,6 +251,22 @@ describe('cli', function () {
         });
     });
 
+    it('should exit without errors when passed a reporter object', function () {
+        var result;
+
+        result = cli({
+            args: [path.dirname(__dirname) + '/data/files/ok.less'],
+            reporter: {
+                name: 'test',
+                report: function () {}
+            }
+        });
+
+        return result.then(function (status) {
+            expect(status).to.equal(0);
+        });
+    });
+
     it('should exit with error when passed a invalid reporter name', function () {
         var result;
 

--- a/test/specs/lesshint.js
+++ b/test/specs/lesshint.js
@@ -185,11 +185,21 @@ describe('lesshint', function () {
     });
 
     describe('getReporter', function () {
-        it('should load the specified reporter', function () {
+        it('should load the specified reporter by path', function () {
             var lesshint = new Lesshint();
             var reporter = lesshint.getReporter(path.resolve(process.cwd() + '/lib/reporters/default.js'));
 
             expect(reporter.name).to.equal('default');
+        });
+
+        it('should load the specified reporter directly', function () {
+            var lesshint = new Lesshint();
+            var reporter = lesshint.getReporter({
+                name: 'test',
+                report: function () {}
+            });
+
+            expect(reporter.name).to.equal('test');
         });
 
         it('should load the default when nothing is passed', function () {


### PR DESCRIPTION
Fixes #282.

I held off from documenting in this PR since until #283 is resolved I don't believe it would be easy for users to use this.