### PR TITLE
excludedFiles should check paths before reading them

### DIFF
--- a/lib/lesshint.js
+++ b/lib/lesshint.js
@@ -13,6 +13,12 @@ var Lesshint = function () {
 };
 
 Lesshint.prototype.checkDirectory = function (checkPath) {
+    if (this.isExcluded(checkPath)) {
+        return new Vow.Promise(function (resolve) {
+            resolve([]);
+        });
+    }
+
     return fs.listDir(checkPath).then(function (files) {
         files = files.map(function (file) {
             var fullPath = path.join(checkPath, file);
@@ -49,6 +55,12 @@ Lesshint.prototype.checkFile = function (checkPath) {
 };
 
 Lesshint.prototype.checkPath = function (checkPath) {
+    if (this.isExcluded(checkPath)) {
+        return new Vow.Promise(function (resolve) {
+            resolve([]);
+        });
+    }
+
     return fs.stat(checkPath).then(function (stats) {
         if (stats.isDirectory()) {
             return this.checkDirectory(checkPath);

--- a/test/specs/lesshint.js
+++ b/test/specs/lesshint.js
@@ -55,6 +55,20 @@ describe('lesshint', function () {
             });
         });
 
+        it('should ignore excluded folders', function () {
+            var testPath = path.join(path.dirname(__dirname), '/data/excluded-files');
+            var lesshint = new Lesshint();
+            var config = {
+                excludedFiles: ['**/excluded-files']
+            };
+
+            lesshint.configure(config);
+
+            return lesshint.checkDirectory(testPath).then(function (result) {
+                expect(result).to.have.length(0);
+            });
+        });
+
         it('should only check files with the correct extension and a leading dot', function () {
             var testPath = path.join(path.dirname(__dirname), '/data/excluded-files');
             var lesshint = new Lesshint();
@@ -118,6 +132,34 @@ describe('lesshint', function () {
 
             return lesshint.checkPath(testDir).then(function (result) {
                 expect(result).to.have.length(2);
+            });
+        });
+
+        it('should ignore excluded files', function () {
+            var testPath = path.join(path.dirname(__dirname), '/data/excluded-files/exclude.less');
+            var lesshint = new Lesshint();
+            var config = {
+                excludedFiles: ['**/excluded-files/*']
+            };
+
+            lesshint.configure(config);
+
+            return lesshint.checkPath(testPath).then(function (result) {
+                expect(result).to.have.length(0);
+            });
+        });
+
+        it('should ignore excluded folders', function () {
+            var testPath = path.join(path.dirname(__dirname), '/data/excluded-files');
+            var lesshint = new Lesshint();
+            var config = {
+                excludedFiles: ['**/excluded-files/*']
+            };
+
+            lesshint.configure(config);
+
+            return lesshint.checkPath(testPath).then(function (result) {
+                expect(result).to.have.length(0);
             });
         });
     });


### PR DESCRIPTION
As discussed in #251.

Can anyone see any BC breaks with this approach? I'm keeping the old `excludedFiles` check since we want people to exclude a single file.