### PR TITLE
Add allowSingleLineRules option to singleLinePerProperty

### DIFF
--- a/lib/config/defaults.json
+++ b/lib/config/defaults.json
@@ -117,7 +117,8 @@
     },
 
     "singleLinePerProperty": {
-        "enabled": true
+        "enabled": true,
+        "allowSingleLineRules": false
     },
 
     "singleLinePerSelector": {

--- a/lib/linters/README.md
+++ b/lib/linters/README.md
@@ -532,6 +532,10 @@ camel case         | .btnPrimary        | `disallowUnderscore`, `disallowDash`
 ## singleLinePerProperty
 Each property should be on its own line.
 
+Option                  | Description
+----------------------- | ------------
+`allowSingleLineRules`  | `false` (**default**), `true`
+
 ### invalid
 ```less
 .foo {

--- a/lib/linters/single_line_per_property.js
+++ b/lib/linters/single_line_per_property.js
@@ -33,6 +33,12 @@ module.exports = {
             return;
         }
 
+        if (config.allowSingleLineRules) {
+            if (node.source.start.line === node.source.end.line && node.nodes.length === 1) {
+                return;
+            }
+        }
+
         node.nodes.forEach(function (child, index) {
             var validBefore;
             var validAfter;

--- a/test/specs/linters/single_line_per_property.js
+++ b/test/specs/linters/single_line_per_property.js
@@ -330,5 +330,65 @@ describe('lesshint', function () {
                 expect(result).to.be.undefined;
             });
         });
+
+        it('should allow single line rules when "allowSingleLineRules" is "true"', function () {
+            var source = '.foo { color: red; }';
+            var options = {
+                allowSingleLineRules: true
+            };
+
+            return spec.parse(source, function (ast) {
+                var result = spec.linter.lint(options, ast.root.first);
+
+                expect(result).to.be.undefined;
+            });
+        });
+
+        it('should not allow single line rules when "allowSingleLineRules" is "false"', function () {
+            var source = '.foo { color: red; }';
+            var options = {
+                allowSingleLineRules: false
+            };
+
+            var expected = [
+                {
+                    column: 8,
+                    line: 1,
+                    message: 'Each property should be on its own line.'
+                }
+            ];
+
+            return spec.parse(source, function (ast) {
+                var result = spec.linter.lint(options, ast.root.first);
+
+                expect(result).to.deep.equal(expected);
+            });
+        });
+
+        it('should not allow single line rules with multiple declarations when "allowSingleLineRules" is "true"', function () {
+            var source = '.foo { color: red; margin-right: 10px; }';
+            var options = {
+                allowSingleLineRules: true
+            };
+
+            var expected = [
+                {
+                    column: 8,
+                    line: 1,
+                    message: 'Each property should be on its own line.'
+                },
+                {
+                    column: 20,
+                    line: 1,
+                    message: 'Each property should be on its own line.'
+                }
+            ];
+
+            return spec.parse(source, function (ast) {
+                var result = spec.linter.lint(options, ast.root.first);
+
+                expect(result).to.deep.equal(expected);
+            });
+        });
     });
 });


### PR DESCRIPTION
I'm not really satisfied with the `allowSingleLineRules` option name. Suggestions welcome!


Closes #269.