### PR TITLE
Moved require('exit') to bin\lesshint

### DIFF
--- a/bin/lesshint
+++ b/bin/lesshint
@@ -1,7 +1,6 @@
 #! /usr/bin/env node
 
 var cli = require('../lib/cli');
-var exit = require('exit');
 
 /**
  * Command line interface for lesshint.
@@ -24,5 +23,5 @@ program
     .parse(process.argv);
 
 cli(program).always(function (status) {
-    exit(status.valueOf());
+    process.exitCode = status.valueOf();
 });

--- a/bin/lesshint
+++ b/bin/lesshint
@@ -1,6 +1,7 @@
 #! /usr/bin/env node
 
 var cli = require('../lib/cli');
+var exit = require('exit');
 
 /**
  * Command line interface for lesshint.
@@ -22,4 +23,4 @@ program
     .option('-x, --max-warnings [int]', 'Number of warnings to trigger nonzero exit code, defaults to 0')
     .parse(process.argv);
 
-cli(program);
+cli(program, exit);

--- a/bin/lesshint
+++ b/bin/lesshint
@@ -23,4 +23,6 @@ program
     .option('-x, --max-warnings [int]', 'Number of warnings to trigger nonzero exit code, defaults to 0')
     .parse(process.argv);
 
-cli(program, exit);
+cli(program).always(function (status) {
+    exit(status.valueOf());
+});

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -15,16 +15,12 @@ var EXIT_CODES = {
     CONFIG: 78
 };
 
-module.exports = function (program, onExit) {
+module.exports = function (program) {
     var lesshint = new Lesshint();
     var exitDefer = Vow.defer();
     var exitPromise = exitDefer.promise();
     var promises = [];
     var config;
-
-    exitPromise.always(function (status) {
-        onExit(status.valueOf());
-    });
 
     if (!program.args.length) {
         console.error('No files to lint were passed. See lesshint -h');

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -4,7 +4,6 @@
 
 var configLoader = require('./config-loader');
 var Lesshint = require('./lesshint');
-var exit = require('exit');
 var Vow = require('vow');
 
 var EXIT_CODES = {
@@ -16,7 +15,7 @@ var EXIT_CODES = {
     CONFIG: 78
 };
 
-module.exports = function (program) {
+module.exports = function (program, onExit) {
     var lesshint = new Lesshint();
     var exitDefer = Vow.defer();
     var exitPromise = exitDefer.promise();
@@ -24,7 +23,7 @@ module.exports = function (program) {
     var config;
 
     exitPromise.always(function (status) {
-        exit(status.valueOf());
+        onExit(status.valueOf());
     });
 
     if (!program.args.length) {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   ],
   "dependencies": {
     "commander": "^2.8.0",
-    "exit": "^0.1.2",
     "lodash.merge": "^4.0.1",
     "lodash.sortby": "^4.0.1",
     "minimatch": "^3.0.2",

--- a/test/specs/cli.js
+++ b/test/specs/cli.js
@@ -2,19 +2,15 @@
 
 'use strict';
 
+var cli = require('../../lib/cli');
 var expect = require('chai').expect;
-var rewire = require('rewire');
 var sinon = require('sinon');
 var path = require('path');
 
 describe('cli', function () {
-    var cli = rewire('../../lib/cli');
-
     beforeEach(function () {
         sinon.stub(process.stdout, 'write');
         sinon.stub(process.stderr, 'write');
-
-        cli.__set__('exit', function () {});
     });
 
     afterEach(function () {


### PR DESCRIPTION
This allows consumers of the CLI function to not randomly close when the exit package is called.

Fixes #281.