### PR TITLE
Changed lib/cli.js to take in a logger

### DIFF
--- a/bin/lesshint
+++ b/bin/lesshint
@@ -22,4 +22,4 @@ program
     .option('-x, --max-warnings [int]', 'Number of warnings to trigger nonzero exit code, defaults to 0')
     .parse(process.argv);
 
-cli(program);
+cli(program, console);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,5 +1,3 @@
-/*eslint no-console: 0*/
-
 'use strict';
 
 var configLoader = require('./config-loader');
@@ -16,7 +14,7 @@ var EXIT_CODES = {
     CONFIG: 78
 };
 
-module.exports = function (program) {
+module.exports = function (program, logger) {
     var lesshint = new Lesshint();
     var exitDefer = Vow.defer();
     var exitPromise = exitDefer.promise();
@@ -28,7 +26,7 @@ module.exports = function (program) {
     });
 
     if (!program.args.length) {
-        console.error('No files to lint were passed. See lesshint -h');
+        logger.error('No files to lint were passed. See lesshint -h');
 
         exitDefer.reject(EXIT_CODES.NOINPUT);
 
@@ -49,7 +47,7 @@ module.exports = function (program) {
             config.linters.push.apply(config.linters, program.linters);
         }
     } catch (e) {
-        console.error("Something's wrong with the config file. Error: " + e.message);
+        logger.error("Something's wrong with the config file. Error: " + e.message);
 
         exitDefer.reject(EXIT_CODES.CONFIG);
 
@@ -70,9 +68,9 @@ module.exports = function (program) {
         reporter = lesshint.getReporter(program.reporter);
 
         if (reporter) {
-            reporter.report(results);
+            reporter.report(results, logger);
         } else {
-            console.error('Could not find reporter "%s".', program.reporter);
+            logger.error('Could not find reporter "%s".', program.reporter);
         }
 
         if (!results.length) {
@@ -106,8 +104,8 @@ module.exports = function (program) {
             }
         }
     }).fail(function (error) {
-        console.error('An unknown error occurred when checking "%s", please file an issue with this info:', error.lesshintFile);
-        console.error(error.stack);
+        logger.error('An unknown error occurred when checking "%s", please file an issue with this info:', error.lesshintFile);
+        logger.error(error.stack);
 
         exitDefer.reject(EXIT_CODES.SOFTWARE);
     });

--- a/lib/reporters/default.js
+++ b/lib/reporters/default.js
@@ -1,10 +1,8 @@
-/*eslint no-console: 0*/
-
 'use strict';
 
 module.exports = {
     name: 'default',
-    report: function report (results) {
+    report: function report (results, logger) {
         results.forEach(function (result) {
             var output = '';
 
@@ -27,7 +25,7 @@ module.exports = {
             output += result.linter + ': ';
             output += result.message;
 
-            console.log(output);
+            logger.log(output);
         });
     }
 };

--- a/lib/reporters/json.js
+++ b/lib/reporters/json.js
@@ -1,10 +1,8 @@
-/*eslint no-console: 0*/
-
 'use strict';
 
 module.exports = {
     name: 'json',
-    report: function report (results) {
-        console.log(JSON.stringify(results));
+    report: function report (results, logger) {
+        logger.log(JSON.stringify(results));
     }
 };

--- a/test/specs/cli.js
+++ b/test/specs/cli.js
@@ -1,5 +1,3 @@
-/*eslint no-console: 0*/
-
 'use strict';
 
 var expect = require('chai').expect;
@@ -11,86 +9,73 @@ describe('cli', function () {
     var cli = rewire('../../lib/cli');
 
     beforeEach(function () {
-        sinon.stub(process.stdout, 'write');
-        sinon.stub(process.stderr, 'write');
-
         cli.__set__('exit', function () {});
     });
 
-    afterEach(function () {
-        if (process.stdout.write.restore) {
-            process.stdout.write.restore();
-        }
-
-        if (process.stderr.write.restore) {
-            process.stderr.write.restore();
-        }
-    });
-
     it('should print error on invalid config file', function () {
-        var result;
-
-        sinon.spy(console, 'error');
-
-        result = cli({
-            args: ['test.less'],
-            config: path.resolve(process.cwd() + '/test/data/config/invalid.json')
-        });
+        var logger = {
+            error: sinon.spy(),
+            log: sinon.spy()
+        };
+        var result = cli(
+            {
+                args: ['test.less'],
+                config: path.resolve(process.cwd() + '/test/data/config/invalid.json')
+            },
+            logger);
 
         return result.fail(function () {
-            var called = console.error.calledOnce;
-
-            console.error.restore();
-
-            expect(called).to.equal(true);
+            expect(logger.error.calledOnce).to.equal(true);
         });
     });
 
     it('should print error when no files are passed', function () {
-        var result;
-
-        sinon.spy(console, 'error');
-
-        result = cli({
-            args: []
-        });
+        var logger = {
+            error: sinon.spy(),
+            log: sinon.spy()
+        };
+        var result = cli(
+            {
+                args: []
+            },
+            logger);
 
         return result.fail(function () {
-            var called = console.error.calledOnce;
-
-            console.error.restore();
-
-            expect(called).to.equal(true);
+            expect(logger.error.calledOnce).to.equal(true);
         });
     });
 
     it('should exit with a non-zero status code when lint errors were found', function () {
-        var result;
-
-        sinon.spy(console, 'log');
-
-        result = cli({
-            args: [path.dirname(__dirname) + '/data/files/file.less'],
-            config: path.resolve(process.cwd() + '/lib/config/defaults.json')
-        });
+        var logger = {
+            error: sinon.spy(),
+            log: sinon.spy()
+        };
+        var result = cli(
+            {
+                args: [path.dirname(__dirname) + '/data/files/file.less'],
+                config: path.resolve(process.cwd() + '/lib/config/defaults.json')
+            },
+            logger);
 
         return result.fail(function (status) {
-            console.log.restore();
-
             expect(status).to.equal(1);
         });
     });
 
     it('should exit with a non-zero status code when lint warnings pass `--max-warnings`', function () {
-        var result;
-
-        result = cli({
-            args: [
-                path.dirname(__dirname) + '/data/files/file.less',
-            ],
-            config: path.resolve(process.cwd() + '/lib/config/defaults.json'),
-            maxWarnings: '0',
-        });
+        var logger = {
+            error: sinon.spy(),
+            log: sinon.spy()
+        };
+        var result = cli(
+            {
+                args: [
+                    path.dirname(__dirname) + '/data/files/file.less',
+                ],
+                config: path.resolve(process.cwd() + '/lib/config/defaults.json'),
+                maxWarnings: '0',
+            },
+            logger);
 
         return result.fail(function (status) {
             expect(status).to.equal(1);
@@ -98,15 +83,19 @@ describe('cli', function () {
     });
 
     it('should exit with a non-zero status code with three warings and `--max-warnings 2`', function () {
-        var result;
-
-        result = cli({
-            args: [
-                path.dirname(__dirname) + '/data/files/file.less',
-            ],
-            config: path.resolve(process.cwd() + '/test/data/config/three-warns.json'),
-            maxWarnings: '2',
-        });
+        var logger = {
+            error: sinon.spy(),
+            log: sinon.spy()
+        };
+        var result = cli(
+            {
+                args: [
+                    path.dirname(__dirname) + '/data/files/file.less',
+                ],
+                config: path.resolve(process.cwd() + '/test/data/config/three-warns.json'),
+                maxWarnings: '2',
+            },
+            logger);
 
         return result.fail(function (status) {
             expect(status).to.equal(1);
@@ -114,15 +103,19 @@ describe('cli', function () {
     });
 
     it('should exit with zero status code with 2 warings and `--max-warnings 2`', function () {
-        var result;
-
-        result = cli({
-            args: [
-                path.dirname(__dirname) + '/data/files/file.less',
-            ],
-            config: path.resolve(process.cwd() + '/test/data/config/two-warns.json'),
-            maxWarnings: '2',
-        });
+        var logger = {
+            error: sinon.spy(),
+            log: sinon.spy()
+        };
+        var result = cli(
+            {
+                args: [
+                    path.dirname(__dirname) + '/data/files/file.less',
+                ],
+                config: path.resolve(process.cwd() + '/test/data/config/two-warns.json'),
+                maxWarnings: '2',
+            },
+            logger);
 
         return result.then(function (status) {
             expect(status).to.equal(0);
@@ -130,15 +123,19 @@ describe('cli', function () {
     });
 
     it('should exit with a zero status code when lint warnings do not pass `--max-warnings`', function () {
-        var result;
-
-        result = cli({
-            args: [
-                path.dirname(__dirname) + '/data/files/file.less',
-            ],
-            config: path.resolve(process.cwd() + '/lib/config/defaults.json'),
-            maxWarnings: '999',
-        });
+        var logger = {
+            error: sinon.spy(),
+            log: sinon.spy()
+        };
+        var result = cli(
+            {
+                args: [
+                    path.dirname(__dirname) + '/data/files/file.less',
+                ],
+                config: path.resolve(process.cwd() + '/lib/config/defaults.json'),
+                maxWarnings: '999',
+            },
+            logger);
 
         return result.then(function (status) {
             expect(status).to.equal(0);
@@ -146,15 +143,19 @@ describe('cli', function () {
     });
 
     it('should exit with a zero status code with `--max-warnings -1` even if lint has warings', function () {
-        var result;
-
-        result = cli({
-            args: [
-                path.dirname(__dirname) + '/data/files/file.less',
-            ],
-            config: path.resolve(process.cwd() + '/lib/config/defaults.json'),
-            maxWarnings: '-1',
-        });
+        var logger = {
+            error: sinon.spy(),
+            log: sinon.spy()
+        };
+        var result = cli(
+            {
+                args: [
+                    path.dirname(__dirname) + '/data/files/file.less',
+                ],
+                config: path.resolve(process.cwd() + '/lib/config/defaults.json'),
+                maxWarnings: '-1',
+            },
+            logger);
 
         return result.then(function (status) {
             expect(status).to.equal(0);
@@ -162,11 +163,15 @@ describe('cli', function () {
     });
 
     it('should exit with a non-zero status code when no files were passed', function () {
-        var result;
-
-        result = cli({
-            args: []
-        });
+        var logger = {
+            error: sinon.spy(),
+            log: sinon.spy()
+        };
+        var result = cli(
+            {
+                args: []
+            },
+            logger);
 
         return result.fail(function (status) {
             expect(status).to.equal(66);
@@ -174,12 +179,16 @@ describe('cli', function () {
     });
 
     it('should exit with a non-zero status code when invalid config file is used', function () {
-        var result;
-
-        result = cli({
-            args: ['test.less'],
-            config: path.resolve(process.cwd() + '/test/data/config/invalid.json')
-        });
+        var logger = {
+            error: sinon.spy(),
+            log: sinon.spy()
+        };
+        var result = cli(
+            {
+                args: ['test.less'],
+                config: path.resolve(process.cwd() + '/test/data/config/invalid.json')
+            },
+            logger);
 
         return result.fail(function (status) {
             expect(status).to.equal(78);
@@ -187,12 +196,16 @@ describe('cli', function () {
     });
 
     it('should ignore excluded files (command-line parameter only)', function () {
-        var result;
-
-        result = cli({
-            args: [path.dirname(__dirname) + '/data/excluded-files'],
-            exclude: '*.less'
-        });
+        var logger = {
+            error: sinon.spy(),
+            log: sinon.spy()
+        };
+        var result = cli(
+            {
+                args: [path.dirname(__dirname) + '/data/excluded-files'],
+                exclude: '*.less'
+            },
+            logger);
 
         return result.then(function (status) {
             expect(status).to.equal(0);
@@ -200,12 +213,16 @@ describe('cli', function () {
     });
 
     it('should ignore excluded files (config file only)', function () {
-        var result;
-
-        result = cli({
-            args: [path.dirname(__dirname) + '/data/excluded-files'],
-            config: path.dirname(__dirname) + '/data/config/config.json'
-        });
+        var logger = {
+            error: sinon.spy(),
+            log: sinon.spy()
+        };
+        var result = cli(
+            {
+                args: [path.dirname(__dirname) + '/data/excluded-files'],
+                config: path.dirname(__dirname) + '/data/config/config.json'
+            },
+            logger);
 
         return result.then(function (status) {
             expect(status).to.equal(0);
@@ -213,13 +230,17 @@ describe('cli', function () {
     });
 
     it('should ignore excluded files (both command-line parameter and config file)', function () {
-        var result;
-
-        result = cli({
-            args: [path.dirname(__dirname) + '/data/excluded-files'],
-            config: path.dirname(__dirname) + '/data/config/exclude-only-one.json',
-            exclude: 'exclude-me-too.less'
-        });
+        var logger = {
+            error: sinon.spy(),
+            log: sinon.spy()
+        };
+        var result = cli(
+            {
+                args: [path.dirname(__dirname) + '/data/excluded-files'],
+                config: path.dirname(__dirname) + '/data/config/exclude-only-one.json',
+                exclude: 'exclude-me-too.less'
+            },
+            logger);
 
         return result.then(function (status) {
             expect(status).to.equal(0);
@@ -227,100 +248,104 @@ describe('cli', function () {
     });
 
     it('should load linters (command-line parameter only)', function () {
-        var result;
-
-        sinon.spy(console, 'log');
-
-        result = cli({
-            args: [path.dirname(__dirname) + '/data/files/file.less'],
-            linters: ['../test/plugins/sampleLinter']
-        });
+        var logger = {
+            error: sinon.spy(),
+            log: sinon.spy()
+        };
+        var result = cli(
+            {
+                args: [path.dirname(__dirname) + '/data/files/file.less'],
+                linters: ['../test/plugins/sampleLinter']
+            },
+            logger);
 
         return result.fail(function (status) {
-            console.log.restore();
-
             expect(status).to.equal(1);
         });
     });
 
     it('should load linters (config file only)', function () {
-        var result;
-
-        sinon.spy(console, 'log');
-
-        result = cli({
-            args: [path.dirname(__dirname) + '/data/files/file.less'],
-            config: path.resolve(process.cwd() + '/test/data/config/linters.json')
-        });
+        var logger = {
+            error: sinon.spy(),
+            log: sinon.spy()
+        };
+        var result = cli(
+            {
+                args: [path.dirname(__dirname) + '/data/files/file.less'],
+                config: path.resolve(process.cwd() + '/test/data/config/linters.json')
+            },
+            logger);
 
         return result.fail(function (status) {
-            console.log.restore();
-
             expect(status).to.equal(1);
         });
     });
 
     it('should load linters (both command-line parameter and config file)', function () {
-        var result;
-
-        sinon.spy(console, 'log');
-
-        result = cli({
-            args: [path.dirname(__dirname) + '/data/files/file.less'],
-            config: path.resolve(process.cwd() + '/test/data/config/linters.json'),
-            linters: ['../test/plugins/otherSampleLinter']
-        });
+        var logger = {
+            error: sinon.spy(),
+            log: sinon.spy()
+        };
+        var result = cli(
+            {
+                args: [path.dirname(__dirname) + '/data/files/file.less'],
+                config: path.resolve(process.cwd() + '/test/data/config/linters.json'),
+                linters: ['../test/plugins/otherSampleLinter']
+            },
+            logger);
 
         return result.fail(function (status) {
-            console.log.restore();
-
             expect(status).to.equal(1);
         });
     });
 
     it('should fail loading linters if a command-line linter errors', function () {
-        var result;
-
-        sinon.spy(console, 'log');
-
-        result = cli({
-            args: [path.dirname(__dirname) + '/data/files/file.less'],
-            config: path.resolve(process.cwd() + '/test/data/config/linters.json'),
-            linters: ['../test/plugins/failingLinter']
-        });
+        var logger = {
+            error: sinon.spy(),
+            log: sinon.spy()
+        };
+        var result = cli(
+            {
+                args: [path.dirname(__dirname) + '/data/files/file.less'],
+                config: path.resolve(process.cwd() + '/test/data/config/linters.json'),
+                linters: ['../test/plugins/failingLinter']
+            },
+            logger);
 
         return result.fail(function (status) {
-            console.log.restore();
-
             expect(status).to.equal(70);
         });
     });
 
     it('should fail loading linters if a config file linter errors', function () {
-        var result;
-
-        sinon.spy(console, 'log');
-
-        result = cli({
-            args: [path.dirname(__dirname) + '/data/files/file.less'],
-            config: path.resolve(process.cwd() + '/test/data/config/linters-failing.json'),
-            linters: ['../test/plugins/sampleLinter']
-        });
+        var logger = {
+            error: sinon.spy(),
+            log: sinon.spy()
+        };
+        var result = cli(
+            {
+                args: [path.dirname(__dirname) + '/data/files/file.less'],
+                config: path.resolve(process.cwd() + '/test/data/config/linters-failing.json'),
+                linters: ['../test/plugins/sampleLinter']
+            },
+            logger);
 
         return result.fail(function (status) {
-            console.log.restore();
-
             expect(status).to.equal(78);
         });
     });
 
     it('should exit without errors when passed a built-in reporter name', function () {
-        var result;
-
-        result = cli({
-            args: [path.dirname(__dirname) + '/data/files/ok.less'],
-            reporter: 'stylish'
-        });
+        var logger = {
+            error: sinon.spy(),
+            log: sinon.spy()
+        };
+        var result = cli(
+            {
+                args: [path.dirname(__dirname) + '/data/files/ok.less'],
+                reporter: 'stylish'
+            },
+            logger);
 
         return result.then(function (status) {
             expect(status).to.equal(0);
@@ -328,12 +353,16 @@ describe('cli', function () {
     });
 
     it('should exit without errors when passed a reporter path', function () {
-        var result;
-
-        result = cli({
-            args: [path.dirname(__dirname) + '/data/files/ok.less'],
-            reporter: '../../lib/reporters/stylish.js'
-        });
+        var logger = {
+            error: sinon.spy(),
+            log: sinon.spy()
+        };
+        var result = cli(
+            {
+                args: [path.dirname(__dirname) + '/data/files/ok.less'],
+                reporter: '../../lib/reporters/stylish.js'
+            },
+            logger);
 
         return result.then(function (status) {
             expect(status).to.equal(0);
@@ -341,15 +370,19 @@ describe('cli', function () {
     });
 
     it('should exit without errors when passed a reporter object', function () {
-        var result;
-
-        result = cli({
-            args: [path.dirname(__dirname) + '/data/files/ok.less'],
-            reporter: {
-                name: 'test',
-                report: function () {}
-            }
-        });
+        var logger = {
+            error: sinon.spy(),
+            log: sinon.spy()
+        };
+        var result = cli(
+            {
+                args: [path.dirname(__dirname) + '/data/files/ok.less'],
+                reporter: {
+                    name: 'test',
+                    report: function () {}
+                }
+            },
+            logger);
 
         return result.then(function (status) {
             expect(status).to.equal(0);
@@ -357,12 +390,16 @@ describe('cli', function () {
     });
 
     it('should exit with error when passed a invalid reporter name', function () {
-        var result;
-
-        result = cli({
-            args: [path.dirname(__dirname) + '/data/files'],
-            reporter: 'invalid-reporter'
-        });
+        var logger = {
+            error: sinon.spy(),
+            log: sinon.spy()
+        };
+        var result = cli(
+            {
+                args: [path.dirname(__dirname) + '/data/files'],
+                reporter: 'invalid-reporter'
+            },
+            logger);
 
         return result.fail(function (status) {
             expect(status).to.equal(1);
@@ -370,12 +407,16 @@ describe('cli', function () {
     });
 
     it('should exit with error when a error is thrown', function () {
-        var result;
-
-        result = cli({
-            args: [path.dirname(__dirname) + '/data/files/foo.less'],
-            config: path.dirname(__dirname) + '/data/config/bad.json'
-        });
+        var logger = {
+            error: sinon.spy(),
+            log: sinon.spy()
+        };
+        var result = cli(
+            {
+                args: [path.dirname(__dirname) + '/data/files/foo.less'],
+                config: path.dirname(__dirname) + '/data/config/bad.json'
+            },
+            logger);
 
         return result.fail(function (status) {
             expect(status).to.equal(70);
@@ -383,18 +424,18 @@ describe('cli', function () {
     });
 
     it('should exit with a error status code when there is at least one result with a severity of "error"', function () {
-        var result;
-
-        sinon.spy(console, 'log');
-
-        result = cli({
-            args: [path.dirname(__dirname) + '/data/files/file.less'],
-            config: path.dirname(__dirname) + '/data/config/severity-error.json'
-        });
+        var logger = {
+            error: sinon.spy(),
+            log: sinon.spy()
+        };
+        var result = cli(
+            {
+                args: [path.dirname(__dirname) + '/data/files/file.less'],
+                config: path.dirname(__dirname) + '/data/config/severity-error.json'
+            },
+            logger);
 
         return result.fail(function (status) {
-            console.log.restore();
-
             expect(status).to.equal(2);
         });
     });

--- a/test/specs/reporters/default.js
+++ b/test/specs/reporters/default.js
@@ -1,34 +1,20 @@
-/*eslint no-console: 0*/
-
 'use strict';
 
 var expect = require('chai').expect;
-var rewire = require('rewire');
+var reporter = require('../../../lib/reporters/default.js');
 var sinon = require('sinon');
 
 describe('reporter:default', function () {
-    var reporter = rewire('../../../lib/reporters/default.js');
-
-    beforeEach(function () {
-        sinon.stub(process.stdout, 'write');
-    });
-
-    afterEach(function () {
-        if (process.stdout.write.restore) {
-            process.stdout.write.restore();
-        }
-    });
 
     it('should not print anything when not passed any errors', function () {
         var errors = [];
+        var logger = {
+            log: sinon.spy()
+        };
 
-        sinon.spy(console, 'log');
+        reporter.report(errors, logger);
 
-        reporter.report(errors);
-
-        expect(console.log.called).to.equal(false);
-
-        console.log.restore();
+        expect(logger.log.called).to.equal(false);
     });
 
     it('should print errors with colors', function () {
@@ -41,16 +27,15 @@ describe('reporter:default', function () {
             message: 'Opening curly brace should be preceded by one space.',
             source: '.foo{ color: red; }'
         }];
+        var logger = {
+            log: sinon.spy()
+        };
 
-        sinon.spy(console, 'log');
+        reporter.report(errors, logger);
 
-        reporter.report(errors);
-
-        message = console.log.getCall(0).args[0];
+        message = logger.log.getCall(0).args[0];
 
         expect(message).to.equal('Warning: file.less: line 1, col 5, spaceBeforeBrace: Opening curly brace should be preceded by one space.');
-
-        console.log.restore();
     });
 
     it('should not print line when not passed one', function () {
@@ -62,16 +47,15 @@ describe('reporter:default', function () {
             message: 'Opening curly brace should be preceded by one space.',
             source: '.foo{ color: red; }'
         }];
+        var logger = {
+            log: sinon.spy()
+        };
 
-        sinon.spy(console, 'log');
+        reporter.report(errors, logger);
 
-        reporter.report(errors);
-
-        message = console.log.getCall(0).args[0];
+        message = logger.log.getCall(0).args[0];
 
         expect(message).to.equal('Warning: file.less: col 5, spaceBeforeBrace: Opening curly brace should be preceded by one space.');
-
-        console.log.restore();
     });
 
     it('should not print column when not passed one', function () {
@@ -83,16 +67,15 @@ describe('reporter:default', function () {
             message: 'Opening curly brace should be preceded by one space.',
             source: '.foo{ color: red; }'
         }];
+        var logger = {
+            log: sinon.spy()
+        };
 
-        sinon.spy(console, 'log');
+        reporter.report(errors, logger);
 
-        reporter.report(errors);
-
-        message = console.log.getCall(0).args[0];
+        message = logger.log.getCall(0).args[0];
 
         expect(message).to.equal('Warning: file.less: line 1, spaceBeforeBrace: Opening curly brace should be preceded by one space.');
-
-        console.log.restore();
     });
 
     it('should print the result severity', function () {
@@ -105,15 +88,14 @@ describe('reporter:default', function () {
             severity: 'error',
             source: '.foo{ color: red; }'
         }];
+        var logger = {
+            log: sinon.spy()
+        };
 
-        sinon.spy(console, 'log');
+        reporter.report(errors, logger);
 
-        reporter.report(errors);
-
-        message = console.log.getCall(0).args[0];
+        message = logger.log.getCall(0).args[0];
 
         expect(message).to.equal('Error: file.less: line 1, spaceBeforeBrace: Opening curly brace should be preceded by one space.');
-
-        console.log.restore();
     });
 });

--- a/test/specs/reporters/json.js
+++ b/test/specs/reporters/json.js
@@ -1,23 +1,10 @@
-/*eslint no-console: 0*/
-
 'use strict';
 
 var expect = require('chai').expect;
-var rewire = require('rewire');
+var reporter = require('../../../lib/reporters/json.js');
 var sinon = require('sinon');
 
 describe('reporter:json', function () {
-    var reporter = rewire('../../../lib/reporters/json.js');
-
-    beforeEach(function () {
-        sinon.stub(process.stdout, 'write');
-    });
-
-    afterEach(function () {
-        if (process.stdout.write.restore) {
-            process.stdout.write.restore();
-        }
-    });
 
     it('should print an error completely', function () {
         var message;
@@ -29,15 +16,14 @@ describe('reporter:json', function () {
             severity: 'error',
             source: '.foo{ color: red; }'
         }];
+        var logger = {
+            log: sinon.spy()
+        };
 
-        sinon.spy(console, 'log');
+        reporter.report(errors, logger);
 
-        reporter.report(errors);
-
-        message = console.log.getCall(0).args[0];
+        message = logger.log.getCall(0).args[0];
 
         expect(message).to.equal(JSON.stringify(errors));
-
-        console.log.restore();
     });
 });


### PR DESCRIPTION
Fixes #300. Allows `lib/cli.js` to take in a logger other than the default global `console`.