### PR TITLE
Linter fix suggestions

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -172,7 +172,7 @@ var runChecks = function (ast, fullPath, lines, linesRaw, config) {
                         + linesRaw.slice(0, piece.line - 1).join('').length
                         - 1;
 
-                    if (config.suggestFixes && linter.suggestFix) {
+                    if (linter.suggestFix) {
                         piece.suggestedFix = linter.suggestFix(piece, options, node);
                     }
 

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -173,7 +173,7 @@ var runChecks = function (ast, fullPath, lines, linesRaw, config) {
                         - 1;
 
                     if (linter.suggestFix) {
-                        piece.suggestedFix = linter.suggestFix(piece, options, node);
+                        piece.suggestedFix = linter.suggestFix(piece, options, node, linesRaw);
                     }
 
                     results.push(piece);

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -172,6 +172,10 @@ var runChecks = function (ast, fullPath, lines, linesRaw, config) {
                         + linesRaw.slice(0, piece.line - 1).join('').length
                         - 1;
 
+                    if (config.suggestFixes && linter.suggestFix) {
+                        piece.suggestedFix = linter.suggestFix(piece, options, node);
+                    }
+
                     results.push(piece);
                 });
             }
@@ -248,7 +252,7 @@ exports.lint = function (input, fullPath, config) {
     lines = input.split('\n');
 
     try {
-        parser = this.getParser(input);
+        parser = exports.getParser(input);
         ast = parser.root.toResult();
 
         results = runChecks(ast, fullPath, lines, linesRaw, config);

--- a/lib/linters/attribute_quotes.js
+++ b/lib/linters/attribute_quotes.js
@@ -35,5 +35,33 @@ module.exports = {
         if (results.length) {
             return results;
         }
+    },
+
+    suggestFix: function fixAttributeQuotesFailure (lint) {
+        var end = lint.position + (lint.source.indexOf(']') - lint.source.indexOf('='));
+
+        return {
+            mutations: [
+                {
+                    insertion: '\'',
+                    range: {
+                        begin: lint.position
+                    },
+                    type: 'text-insert'
+                },
+                {
+                    insertion: '\'',
+                    range: {
+                        begin: end
+                    },
+                    type: 'text-insert'
+                }
+            ],
+            range: {
+                begin: lint.position,
+                end: end
+            },
+            type: 'multiple'
+        };
     }
 };

--- a/lib/linters/border_zero.js
+++ b/lib/linters/border_zero.js
@@ -51,12 +51,19 @@ module.exports = {
     },
 
     suggestFix: function fixBorderZeroFailure (lint, config) {
-        var length = config.style === 'zero'
-            ? 'none'.length
-            : '0'.length;
+        var insertion;
+        var length;
+
+        if (config.style === 'zero') {
+            insertion = '0';
+            length = 'none'.length;
+        } else {
+            insertion = 'none';
+            length = '0'.length;
+        }
 
         return {
-            insertion: '0',
+            insertion: insertion,
             range: {
                 begin: lint.position,
                 end: lint.position + length

--- a/lib/linters/border_zero.js
+++ b/lib/linters/border_zero.js
@@ -48,5 +48,20 @@ module.exports = {
                 message: message
             }];
         }
+    },
+
+    suggestFix: function fixBorderZeroFailure (lint, config) {
+        var length = config.style === 'zero'
+            ? 'none'.length
+            : '0'.length;
+
+        return {
+            insertion: '0',
+            range: {
+                begin: lint.position,
+                end: lint.position + length
+            },
+            type: 'text-swap'
+        };
     }
 };

--- a/lib/linters/comment.js
+++ b/lib/linters/comment.js
@@ -21,5 +21,17 @@ module.exports = {
                 message: this.message
             }];
         }
+    },
+
+    suggestFix: function fixCommentFailure (lint, config, node, linesRaw) {
+        var originalInput = linesRaw.join('');
+
+        return {
+            range: {
+                begin: lint.position,
+                end: originalInput.indexOf('*/', lint.position) + '*/'.length
+            },
+            type: 'text-delete'
+        };
     }
 };

--- a/lib/linters/final_newline.js
+++ b/lib/linters/final_newline.js
@@ -17,5 +17,23 @@ module.exports = {
                 message: this.message
             }];
         }
+    },
+
+    suggestFix: function fixFinalNewlineFailure (lint, config, node, rawLines) {
+        var useWindowsEndlines;
+
+        if (rawLines.length > 1 && rawLines[0][rawLines[0].length - 1] === '\n') {
+            useWindowsEndlines = rawLines[0].substring(rawLines[0].length - 2) === '\r\n';
+        } else {
+            useWindowsEndlines = process.platform.indexOf('win') === 0;
+        }
+
+        return {
+            insertion: useWindowsEndlines ? '\r\n' : '\n',
+            range: {
+                begin: lint.position
+            },
+            type: 'text-insert'
+        };
     }
 };

--- a/lib/linters/trailing_semicolon.js
+++ b/lib/linters/trailing_semicolon.js
@@ -26,5 +26,15 @@ module.exports = {
         if (results.length) {
             return results;
         }
+    },
+
+    suggestFix: function suggestTrailingSemicolonFix (lint) {
+        return {
+            insertion: ';',
+            range: {
+                begin: lint.position + 2
+            },
+            type: 'text-insert'
+        };
     }
 };

--- a/lib/linters/trailing_semicolon.js
+++ b/lib/linters/trailing_semicolon.js
@@ -32,7 +32,7 @@ module.exports = {
         return {
             insertion: ';',
             range: {
-                begin: lint.position + 2
+                begin: lint.position
             },
             type: 'text-insert'
         };

--- a/lib/linters/trailing_whitespace.js
+++ b/lib/linters/trailing_whitespace.js
@@ -36,7 +36,7 @@ module.exports = {
         }
     },
 
-    suggestFix: function suggestTrailingWhitespaceFix (lint) {
+    suggestFix: function fixTrailingWhitespaceFailure (lint) {
         var whitespaceParts = lint.source.split(/\S/);
 
         return {

--- a/lib/linters/trailing_whitespace.js
+++ b/lib/linters/trailing_whitespace.js
@@ -34,5 +34,17 @@ module.exports = {
         if (results.length) {
             return results;
         }
+    },
+
+    suggestFix: function suggestTrailingWhitespaceFix (lint) {
+        var whitespaceParts = lint.source.split(/\S/);
+
+        return {
+            range: {
+                begin: lint.position - whitespaceParts[whitespaceParts.length - 1].length + 1,
+                end: lint.position + 1
+            },
+            type: 'text-delete'
+        };
     }
 };

--- a/lib/linters/url_quotes.js
+++ b/lib/linters/url_quotes.js
@@ -60,5 +60,33 @@ module.exports = {
         if (results.length) {
             return results;
         }
+    },
+
+    suggestFix: function fixUrlQuotesFailure (lint) {
+        var end = lint.position + lint.source.indexOf(')', lint.column) - lint.column + 2;
+
+        return {
+            mutations: [
+                {
+                    insertion: '\'',
+                    range: {
+                        begin: lint.position
+                    },
+                    type: 'text-insert'
+                },
+                {
+                    insertion: '\'',
+                    range: {
+                        begin: end
+                    },
+                    type: 'text-insert'
+                }
+            ],
+            range: {
+                begin: lint.position,
+                end: end
+            },
+            type: 'multiple'
+        };
     }
 };

--- a/test/specs/linter.js
+++ b/test/specs/linter.js
@@ -118,7 +118,30 @@ describe('linter', function () {
                     message: 'Attribute selectors should use quotes.',
                     position: 21,
                     severity: 'warning',
-                    source: '[type="text"], [type=email] {'
+                    source: '[type="text"], [type=email] {',
+                    suggestedFix: {
+                        mutations: [
+                            {
+                                insertion: '\'',
+                                range: {
+                                    begin: 21
+                                },
+                                type: 'text-insert'
+                            },
+                            {
+                                insertion: '\'',
+                                range: {
+                                    begin: 28
+                                },
+                                type: 'text-insert'
+                            }
+                        ],
+                        range: {
+                            begin: 21,
+                            end: 28
+                        },
+                        type: 'multiple'
+                    }
                 },
                 {
                     column: 1,

--- a/test/specs/linters/border_zero.js
+++ b/test/specs/linters/border_zero.js
@@ -181,7 +181,7 @@ describe('lesshint', function () {
                 style: 'none'
             };
             var expectedFixes = [{
-                insertion: '0',
+                insertion: 'none',
                 range: {
                     begin: 15,
                     end: 16,

--- a/test/specs/linters/border_zero.js
+++ b/test/specs/linters/border_zero.js
@@ -169,9 +169,10 @@ describe('lesshint', function () {
                 },
                 type: 'text-swap'
             }];
-            var suggestedFixes = spec.suggestFixes(source, options);
 
-            expect(suggestedFixes).to.deep.equal(expectedFixes);
+            spec.suggestFixes(source, options, function (suggestedFixes) {
+                expect(suggestedFixes).to.deep.equal(expectedFixes);
+            });
         });
 
         it('should suggest changing "0" to "none"', function () {
@@ -187,9 +188,10 @@ describe('lesshint', function () {
                 },
                 type: 'text-swap'
             }];
-            var suggestedFixes = spec.suggestFixes(source, options);
 
-            expect(suggestedFixes).to.deep.equal(expectedFixes);
+            spec.suggestFixes(source, options, function (suggestedFixes) {
+                expect(suggestedFixes).to.deep.equal(expectedFixes);
+            });
         });
     });
 });

--- a/test/specs/linters/border_zero.js
+++ b/test/specs/linters/border_zero.js
@@ -155,5 +155,41 @@ describe('lesshint', function () {
                 expect(lint).to.throw(Error);
             });
         });
+
+        it('should suggest changing "none" to "0"', function () {
+            var source = '.foo { border: none; }';
+            var options = {
+                style: 'zero'
+            };
+            var expectedFixes = [{
+                insertion: '0',
+                range: {
+                    begin: 15,
+                    end: 19,
+                },
+                type: 'text-swap'
+            }];
+            var suggestedFixes = spec.suggestFixes(source, options);
+
+            expect(suggestedFixes).to.deep.equal(expectedFixes);
+        });
+
+        it('should suggest changing "0" to "none"', function () {
+            var source = '.foo { border: 0; }';
+            var options = {
+                style: 'none'
+            };
+            var expectedFixes = [{
+                insertion: '0',
+                range: {
+                    begin: 15,
+                    end: 16,
+                },
+                type: 'text-swap'
+            }];
+            var suggestedFixes = spec.suggestFixes(source, options);
+
+            expect(suggestedFixes).to.deep.equal(expectedFixes);
+        });
     });
 });

--- a/test/specs/linters/comment.js
+++ b/test/specs/linters/comment.js
@@ -49,5 +49,20 @@ describe('lesshint', function () {
                 expect(result).to.be.undefined;
             });
         });
+
+        it('should suggest deleting a multiline comment', function () {
+            var source = '/* Hello world */';
+            var expectedFixes = [{
+                range: {
+                    begin: 0,
+                    end: 17,
+                },
+                type: 'text-delete'
+            }];
+
+            return spec.suggestFixes(source, {}, function (suggestedFixes) {
+                expect(suggestedFixes).to.deep.equal(expectedFixes);
+            });
+        });
     });
 });

--- a/test/specs/linters/final_newline.js
+++ b/test/specs/linters/final_newline.js
@@ -69,5 +69,50 @@ describe('lesshint', function () {
                 expect(result).to.deep.equal(expected);
             });
         });
+
+        it('should suggest adding a final Unix endline for Unix files', function () {
+            var source = '.foo {}\n\n.bar {}';
+            var expectedFixes = [{
+                insertion: '\n',
+                range: {
+                    begin: 22 // see #310
+                },
+                type: 'text-insert'
+            }];
+
+            return spec.suggestFixes(source, {}, function (suggestedFixes) {
+                expect(suggestedFixes).to.deep.equal(expectedFixes);
+            });
+        });
+
+        it('should suggest adding a final Windows endline for Windows files', function () {
+            var source = '.foo {}\r\n\r\n.bar {}';
+            var expectedFixes = [{
+                insertion: '\r\n',
+                range: {
+                    begin: 18
+                },
+                type: 'text-insert'
+            }];
+
+            return spec.suggestFixes(source, {}, function (suggestedFixes) {
+                expect(suggestedFixes).to.deep.equal(expectedFixes);
+            });
+        });
+
+        it('should suggest a platform-specific endline for single-line files', function () {
+            var source = '.foo {}';
+            var expectedFixes = [{
+                insertion: process.platform.indexOf('win') === 0 ? '\r\n' : '\n',
+                range: {
+                    begin: 7
+                },
+                type: 'text-insert'
+            }];
+
+            return spec.suggestFixes(source, {}, function (suggestedFixes) {
+                expect(suggestedFixes).to.deep.equal(expectedFixes);
+            });
+        });
     });
 });

--- a/test/specs/linters/trailing_semicolon.js
+++ b/test/specs/linters/trailing_semicolon.js
@@ -107,9 +107,10 @@ describe('lesshint', function () {
                 },
                 type: 'text-insert'
             }];
-            var suggestedFixes = spec.suggestFixes(source);
 
-            expect(suggestedFixes).to.deep.equal(expectedFixes);
+            return spec.suggestFixes(source, {}, function (suggestedFixes) {
+                expect(suggestedFixes).to.deep.equal(expectedFixes);
+            });
         });
     });
 });

--- a/test/specs/linters/trailing_semicolon.js
+++ b/test/specs/linters/trailing_semicolon.js
@@ -97,5 +97,19 @@ describe('lesshint', function () {
                 expect(result).to.be.undefined;
             });
         });
+
+        it('should suggest inserting a missing semicolon', function () {
+            var source = '.foo{ color:red }\n';
+            var expectedFixes = [{
+                insertion: ';',
+                range: {
+                    begin: 17
+                },
+                type: 'text-insert'
+            }];
+            var suggestedFixes = spec.suggestFixes(source);
+
+            expect(suggestedFixes).to.deep.equal(expectedFixes);
+        });
     });
 });

--- a/test/specs/linters/trailing_semicolon.js
+++ b/test/specs/linters/trailing_semicolon.js
@@ -103,7 +103,7 @@ describe('lesshint', function () {
             var expectedFixes = [{
                 insertion: ';',
                 range: {
-                    begin: 17
+                    begin: 15
                 },
                 type: 'text-insert'
             }];

--- a/test/specs/linters/trailing_whitespace.js
+++ b/test/specs/linters/trailing_whitespace.js
@@ -72,5 +72,19 @@ describe('lesshint', function () {
                 expect(result).to.be.undefined;
             });
         });
+
+        it('should suggest deleting trailing whitespace', function () {
+            var source = '.foo {}  ';
+            var expectedFixes = [{
+                range: {
+                    begin: 7,
+                    end: 9
+                },
+                type: 'text-delete'
+            }];
+            var suggestedFixes = spec.suggestFixes(source);
+
+            expect(suggestedFixes).to.deep.equal(expectedFixes);
+        });
     });
 });

--- a/test/specs/linters/trailing_whitespace.js
+++ b/test/specs/linters/trailing_whitespace.js
@@ -82,9 +82,10 @@ describe('lesshint', function () {
                 },
                 type: 'text-delete'
             }];
-            var suggestedFixes = spec.suggestFixes(source);
 
-            expect(suggestedFixes).to.deep.equal(expectedFixes);
+            return spec.suggestFixes(source, {}, function (suggestedFixes) {
+                expect(suggestedFixes).to.deep.equal(expectedFixes);
+            });
         });
     });
 });

--- a/test/specs/linters/url_quotes.js
+++ b/test/specs/linters/url_quotes.js
@@ -167,5 +167,36 @@ describe('lesshint', function () {
                 expect(result).to.deep.equal(expected);
             });
         });
+
+        it('should suggest adding quotes to a url', function () {
+            var source = 'background-image: url(img/image.jpg);';
+            var expectedFixes = [{
+                mutations: [
+                    {
+                        insertion: '\'',
+                        range: {
+                            begin: 22
+                        },
+                        type: 'text-insert'
+                    },
+                    {
+                        insertion: '\'',
+                        range: {
+                            begin: 36
+                        },
+                        type: 'text-insert'
+                    }
+                ],
+                range: {
+                    begin: 22,
+                    end: 36
+                },
+                type: 'multiple'
+            }];
+
+            return spec.suggestFixes(source, {}, function (suggestedFixes) {
+                expect(suggestedFixes).to.deep.equal(expectedFixes);
+            });
+        });
     });
 });

--- a/test/specs/util.js
+++ b/test/specs/util.js
@@ -4,13 +4,34 @@ var path = require('path');
 var getParser = require('../../lib/linter').getParser;
 var lint = require('../../lib/linter').lint;
 
+// tests selectors for pseudo classes/selectors. eg. :not(), :active
+var rPseudo = /::?[^ ,:.]+/g;
+
+function cleanAst (ast) {
+    // if we're dealing with a regular Rule (or other) node, which isn't
+    // an actual Mixin or AtRule, and its selector contains a pseudo
+    // class or selector, then clean up the raws and params properties.
+    // if we don't have this here, then the tests never get the same
+    // modified nodes.
+    // tracking: https://github.com/webschik/postcss-less/issues/56
+    // TODO: remove this when issue resolved
+    ast.root.walk(function (node) {
+        if (node.params && rPseudo.test(node.selector)) {
+            delete node.params;
+
+            // this just started showing up in postcss-less@0.14.0. not sure
+            // if it's sticking around, but making sure we're thorough.
+            if (node.raws.params) {
+                delete node.raws.params;
+            }
+        }
+    });
+}
+
 module.exports = {
     setup: function setup () {
         var filename = '../../lib/linters/';
         var linter;
-
-        // tests selectors for pseudo classes/selectors. eg. :not(), :active
-        var rPseudo = /::?[^ ,:.]+/g;
 
         // slightly evil, but it's OK since this is just for specs
         // nodejs caches module.parent as the first module to require it,
@@ -31,36 +52,28 @@ module.exports = {
             parser: getParser,
             parse: function (source, callback) {
                 return getParser(source).then(function (ast) {
-                    // if we're dealing with a regular Rule (or other) node, which isn't
-                    // an actual Mixin or AtRule, and its selector contains a pseudo
-                    // class or selector, then clean up the raws and params properties.
-                    // if we don't have this here, then the tests never get the same
-                    // modified nodes.
-                    // tracking: https://github.com/webschik/postcss-less/issues/56
-                    // TODO: remove this when issue resolved
-                    ast.root.walk(function (node) {
-                        if (node.params && rPseudo.test(node.selector)) {
-                            delete node.params;
-
-                            // this just started showing up in postcss-less@0.14.0. not sure
-                            // if it's sticking around, but making sure we're thorough.
-                            if (node.raws.params) {
-                                delete node.raws.params;
-                            }
-                        }
-                    });
-
+                    cleanAst(ast);
                     callback && callback(ast);
                 });
             },
-            suggestFixes: function (source, options) {
+            suggestFixes: function (source, options, callback) {
                 var config = {};
 
-                config[linter.name] = options || {};
-                config[linter.name].enabled = true;
+                config[linter.name] = options;
+                options.enabled = true;
 
-                return lint(source, filename, config).map(function (lint) {
-                    return linter.suggestFix(lint, config[linter.name]);
+                return getParser(source).then(function (ast) {
+                    var linesRaw = source.match(/[^\n]+(?:\r?\n|$)/g); // Include trailing line endings
+                    var results;
+
+                    cleanAst(ast);
+
+                    results = lint(source, filename, config)
+                        .map(function (lint) {
+                            return linter.suggestFix(lint, config[linter.name], ast.root.first, linesRaw);
+                        });
+
+                    callback && callback(results);
                 });
             }
         };

--- a/test/specs/util.js
+++ b/test/specs/util.js
@@ -53,14 +53,15 @@ module.exports = {
                     callback && callback(ast);
                 });
             },
-            suggestFixes: function (source) {
-                var config = {
-                    suggestFixes: true
-                };
+            suggestFixes: function (source, options) {
+                var config = {};
 
-                config[linter.name] = true;
+                config[linter.name] = options || {};
+                config[linter.name].enabled = true;
 
-                return lint(source, filename, config).map(linter.suggestFix);
+                return lint(source, filename, config).map(function (lint) {
+                    return linter.suggestFix(lint, config[linter.name]);
+                });
             }
         };
     }

--- a/test/specs/util.js
+++ b/test/specs/util.js
@@ -2,6 +2,7 @@
 
 var path = require('path');
 var getParser = require('../../lib/linter').getParser;
+var lint = require('../../lib/linter').lint;
 
 module.exports = {
     setup: function setup () {
@@ -51,6 +52,15 @@ module.exports = {
 
                     callback && callback(ast);
                 });
+            },
+            suggestFixes: function (source) {
+                var config = {
+                    suggestFixes: true
+                };
+
+                config[linter.name] = true;
+
+                return lint(source, filename, config).map(linter.suggestFix);
             }
         };
     }


### PR DESCRIPTION
Linters can now provide a `suggestFix` method. It should take in their lint and return an `automutate`-style fix suggestion. These are added to lint pieces as `suggestedFix`.

Implemented for the following rules:
- [x] attribute_quotes
- [x] border_zero
- [x] comment
- [ ] decimal_zero
- [ ] depth_level
- [ ] duplicate_property
- [ ] empty_rule
- [x] final_newline
- [ ] hex_length
- [ ] hex_notation
- [ ] hex_validation
- [ ] id_selector
- [ ] import_path
- [ ] important_rule
- [ ] max_char_per_line
- [ ] newline_after_block
- [ ] property_ordering
- [ ] property_units
- [ ] qualifying_element
- [ ] selector_naming
- [ ] single_line_per_property
- [ ] single_line_per_selector
- [ ] space_after_property_colon
- [ ] space_after_property_name
- [ ] space_after_property_value
- [ ] space_around_comma
- [ ] space_around_operator
- [ ] space_before_brace
- [ ] space_between_parens
- [ ] string_quotes
- [x] trailing_semicolon
- [x] trailing_whitespace
- [ ] url_format
- [x] url_quotes
- [ ] zero_unit

Fixes #278.