### PR TITLE
Utilise ES6 default parameters

### DIFF
--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -17,9 +17,7 @@ const loadConfig = function (path) {
     return JSON.parse(data);
 };
 
-module.exports = function (path) {
-    path = path || process.cwd();
-
+module.exports = function (path = process.cwd()) {
     const stats = fs.statSync(path);
     let config;
 

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -72,9 +72,7 @@ const parseRules = function (node) {
     return rules;
 };
 
-const getInlineOptions = function (node) {
-    node = node || {};
-
+const getInlineOptions = function (node = {}) {
     if (node.type !== 'comment') {
         return {};
     }
@@ -200,9 +198,7 @@ const runChecks = function (ast, fullPath, lines, linesRaw, config) {
     checkNode(ast.root);
 
     // Walk through and check each node within (but not including) root
-    ast.root.walk(function (node) {
-        checkNode(node);
-    });
+    ast.root.walk(checkNode);
 
     return results;
 };


### PR DESCRIPTION
Minor refactor of config loader and linter to use ES6 default parameters.