### PR TITLE
Documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,15 @@ It's also possible to define your own linters to add to the built-in list. These
 "linters": [
     "./plugins/linters/sampleLinter",
     require("./plugins/linters/otherSampleLinter")
-]
+],
+
+"sample": {
+    "enabled": true
+},
+
+"otherSample": {
+    "enabled": true
+}
 ```
 
 
@@ -178,6 +186,7 @@ module.exports = {
         // Return the results
         return results;
     }
+};
 ```
 
 We highly recommend the following resources which are all included with `lesshint`.


### PR DESCRIPTION
I was looking to use custom linters in my project and found one small error in the sample custom linter code in the `README` so I fix it. Additionally, it wasn't clear from the `README` that custom linters defined in `lesshintrc` must also be enabled. My impression was they are enabled by default as a result of their definition, so I updated the docs to call they must also be enabled.