### PR TITLE
Added a process.cwd check for requiring linters

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -220,11 +220,18 @@ const mergeLintersFromConfig = function (defaultLinters, config) {
 };
 
 const requireConfigLinter = function (linter) {
-    if (typeof linter === 'string') {
-        return require(linter);
+    if (typeof linter !== 'string') {
+        return linter;
     }
 
-    return linter;
+    let pathToLinter;
+    try {
+        pathToLinter = require.resolve(path.join(process.cwd(), linter));
+    } catch (e) {
+        pathToLinter = require.resolve(linter);
+    }
+
+    return require(pathToLinter);
 };
 
 exports.resultSeverity = {


### PR DESCRIPTION
Fixes #327.

You can't just politely ask `require` if something exists; you can only attempt to load it and try/catch the logic. 