### PR TITLE
Replace istanbul with nyc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.nyc_output
 coverage
 node_modules
 npm-debug.log

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,4 @@
 const gulp = require('gulp');
-const istanbul = require('gulp-istanbul');
 
 gulp.task('lint', () => {
     const eslint = require('gulp-eslint');
@@ -10,23 +9,13 @@ gulp.task('lint', () => {
         .pipe(eslint.failAfterError());
 });
 
-gulp.task('coverage', ['lint'], () => {
-    return gulp.src(['./lib/**/*.js'])
-        .pipe(istanbul())
-        .pipe(istanbul.hookRequire());
-});
-
-gulp.task('test', ['coverage'], () => {
+gulp.task('test', ['lint'], () => {
     const mocha = require('gulp-mocha');
 
-    return gulp.src(['./test/specs/**/*.js', '!./test/specs/util.js'])
-        .pipe(mocha())
-        .pipe(istanbul.writeReports())
-        .pipe(istanbul.enforceThresholds({
-            thresholds: {
-                global: 95
-            }
-        }));
+    return gulp.src(['./test/specs/**/*.js', '!./test/specs/util.js'], {
+            read: false
+        })
+        .pipe(mocha());
 });
 
 gulp.task('coveralls', ['test'], () => {

--- a/package.json
+++ b/package.json
@@ -36,8 +36,9 @@
     "gulp": "^3.9.0",
     "gulp-coveralls": "^0.1.4",
     "gulp-eslint": "^3.0.1",
-    "gulp-istanbul": "^1.1.1",
     "gulp-mocha": "^4.0.0",
+    "mocha": "^3.2.0",
+    "nyc": "^10.1.2",
     "rimraf": "^2.4.2",
     "sinon": "^1.14.1"
   },
@@ -45,10 +46,21 @@
     "lesshint": "bin/lesshint"
   },
   "scripts": {
-    "test": "gulp"
+    "test": "nyc gulp"
   },
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/lesshint/lesshint/issues"
+  },
+  "nyc": {
+    "lines": 95,
+    "statements": 95,
+    "functions": 95,
+    "branches": 95,
+    "check-coverage": true,
+    "reporter": [
+      "lcov",
+      "text-summary"
+    ]
   }
 }


### PR DESCRIPTION
Since `gulp-mocha 4.0` spawns a child process we need a coverage tool that handles that.
To get it working on older npm versions which doesn't dedupe by default, we need to explicitly include mocha as a dependency as well.

Thanks to @kokarn for the rubber ducking session!

<!--
If you're submitting a PR for a new feature, please open an issue about it first so we can discuss it.
If you're submitting a PR for something else, for example a documentation fix, go right ahead!
-->

**Which issue, if any, does this resolve?**
N/A

**Is there anything in this PR that needs extra explaining or should something specific be focused on?**
Nope, it should be self-explanatory.