### PR TITLE
Allow negative values before a (. Close #349

### DIFF
--- a/lib/linters/space_around_operator.js
+++ b/lib/linters/space_around_operator.js
@@ -25,10 +25,9 @@ module.exports = {
             const prevElement = child.parent.nodes[index - 1];
 
 
-        // Ignore negative numbers
+            // Ignore negative numbers
             if (child.value === '-' && (child.raws.before || node.raws.between) &&
-                (nextElement.type === 'number' || nextElement.value === '(')
-                && !nextElement.raws.before) {
+                (nextElement.type === 'number' || nextElement.value === '(') && !nextElement.raws.before) {
                 return;
             }
             // Ignore variables

--- a/lib/linters/space_around_operator.js
+++ b/lib/linters/space_around_operator.js
@@ -24,12 +24,13 @@ module.exports = {
             const nextElement = child.parent.nodes[index + 1];
             const prevElement = child.parent.nodes[index - 1];
 
-            // Ignore negative numbers
+
+        // Ignore negative numbers
             if (child.value === '-' && (child.raws.before || node.raws.between) &&
-                nextElement.type === 'number' && !nextElement.raws.before) {
+                (nextElement.type === 'number' || nextElement.value === '(')
+                && !nextElement.raws.before) {
                 return;
             }
-
             // Ignore variables
             if (child.value === '-' && (child.raws.before || node.raws.between) &&
                 nextElement.type === 'atword' && !nextElement.raws.before) {

--- a/test/specs/linters/space_around_operator.js
+++ b/test/specs/linters/space_around_operator.js
@@ -84,6 +84,16 @@ describe('lesshint', function () {
                 });
             });
 
+            it('should not report on negative values before a (', function () {
+                const source = 'margin-left: -(10px);';
+
+                return spec.parse(source, function (ast) {
+                    const result = spec.linter.lint(options, ast.root.first);
+
+                    expect(result).to.be.undefined;
+                });
+            });
+
             it('should not report on negative values in shorthands', function () {
                 const source = 'margin: -10px -1px 0px 20px;';
 


### PR DESCRIPTION
**Which issue, if any, does this resolve?**
Solve #349 

```css
h {
    margin-left: -(1px); // fails
}
```
**Is there anything in this PR that needs extra explaining or should something specific be focused on?**

Nope. A lot of copy/paste code in the test section.

I am not sure about my changes. Any help is welcome!