### PR TITLE
Handle both strings and error objects in custom errors

### DIFF
--- a/lib/errors/lesshint-error.js
+++ b/lib/errors/lesshint-error.js
@@ -8,7 +8,7 @@ class LesshintError extends Error {
 
         errorPath = errorPath || error.path;
 
-        this.message = error.message;
+        this.message = error.message || error;
         this.name = this.constructor.name;
         this.path = path.resolve(process.cwd(), errorPath);
         this.stack = error.stack;

--- a/lib/errors/runner-error.js
+++ b/lib/errors/runner-error.js
@@ -4,7 +4,7 @@ class RunnerError extends Error {
     constructor (error, status) {
         super(error);
 
-        this.message = error.message;
+        this.message = error.message || error;
         this.name = this.constructor.name;
         this.status = status;
         this.stack = error.stack;

--- a/test/specs/errors/lesshint-error.js
+++ b/test/specs/errors/lesshint-error.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const LesshintError = require('../../../lib/errors/lesshint-error');
+const expect = require('chai').expect;
+const path = require('path');
+
+describe('LesshintError', function () {
+    it('should handle an Error object', function () {
+        const message = 'Something went wrong';
+        const error = new Error(message);
+
+        const lesshintError = new LesshintError(error, '/path/to/file.less');
+
+        expect(lesshintError.message).to.equal(message);
+    });
+
+    it('should handle a a string', function () {
+        const message = 'Something went wrong';
+
+        const lesshintError = new LesshintError(message, '/path/to/file.less');
+
+        expect(lesshintError.message).to.equal(message);
+    });
+
+    it('should resolve paths', function () {
+        const file = 'file.less';
+        const errorPath = path.resolve(process.cwd(), file);
+
+        const lesshintError = new LesshintError('Something went wrong', file);
+
+        expect(lesshintError.path).to.equal(errorPath);
+    });
+});

--- a/test/specs/errors/runner-error.js
+++ b/test/specs/errors/runner-error.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const RunnerError = require('../../../lib/errors/runner-error');
+const expect = require('chai').expect;
+
+describe('RunnerError', function () {
+    it('should handle an Error object', function () {
+        const message = 'Something went wrong';
+        const error = new Error(message);
+
+        const runnerError = new RunnerError(error, 1);
+
+        expect(runnerError.message).to.equal(message);
+    });
+
+    it('should handle a a string', function () {
+        const message = 'Something went wrong';
+
+        const runnerError = new RunnerError(message, 1);
+
+        expect(runnerError.message).to.equal(message);
+    });
+
+    it('should set the status', function () {
+        const status = 1;
+        const runnerError = new RunnerError('Something went wrong', status);
+
+        expect(runnerError.status).to.equal(status);
+    });
+});


### PR DESCRIPTION
<!--
If you're submitting a PR for a new feature, please open an issue about it first so we can discuss it.
If you're submitting a PR for something else, for example a documentation fix, go right ahead!
-->

**Which issue, if any, does this resolve?**
Point 3 of #357, kinda. Since we broke that functionality in `3.0` with our custom errors which this commit fixes.

**Is there anything in this PR that needs extra explaining or should something specific be focused on?**
Not really.