### PR TITLE
If custom linter is not found, look for it based on location of config file | added colorVariables linter

### DIFF
--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -14,7 +14,9 @@ const loadConfig = function (path) {
         data = data.slice(1);
     }
 
-    return JSON.parse(data);
+    data = JSON.parse(data);
+    data._path = path;
+    return data;
 };
 
 module.exports = function (path) {

--- a/lib/config/defaults.json
+++ b/lib/config/defaults.json
@@ -15,7 +15,7 @@
     
     "colorVariables": {
         "enabled": true   
-    }
+    },
 
     "comment": {
         "allowed": "^!",

--- a/lib/config/defaults.json
+++ b/lib/config/defaults.json
@@ -14,7 +14,7 @@
     },
     
     "colorVariables": {
-        "enabled": true   
+        "enabled": false   
     },
 
     "comment": {

--- a/lib/config/defaults.json
+++ b/lib/config/defaults.json
@@ -12,6 +12,10 @@
         "enabled": true,
         "style": "zero"
     },
+    
+    "colorVariables": {
+        "enabled": true   
+    }
 
     "comment": {
         "allowed": "^!",

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -9,6 +9,7 @@ const path = require('path');
 const defaultLinters = [
     require('./linters/attribute_quotes'),
     require('./linters/border_zero'),
+    require('./linters/color_variables'),
     require('./linters/comment'),
     require('./linters/decimal_zero'),
     require('./linters/depth_level'),

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -260,11 +260,15 @@ class Linter {
             }
 
             let linterPath;
-
             try {
-                linterPath = require.resolve(path.join(process.cwd(), linter));
+                try {
+                    linterPath = require.resolve(path.join(process.cwd(), linter));
+                } catch (e) {
+                    linterPath = require.resolve(linter);
+                }
             } catch (e) {
-                linterPath = require.resolve(linter);
+                const pathBasedOnConfig = this.options._path.replace('.lesshintrc', linter);
+                linterPath = require.resolve(pathBasedOnConfig);
             }
 
             return require(linterPath);

--- a/lib/linters/README.md
+++ b/lib/linters/README.md
@@ -2,7 +2,7 @@
 
 * [attributeQuotes](#attributequotes)
 * [borderZero](#borderzero)
-* [colorVariables](#colorVariables)
+* [colorVariables](#colorvariables)
 * [comment](#comment)
 * [decimalZero](#decimalzero)
 * [depthLevel](#depthlevel)

--- a/lib/linters/README.md
+++ b/lib/linters/README.md
@@ -2,6 +2,7 @@
 
 * [attributeQuotes](#attributequotes)
 * [borderZero](#borderzero)
+* [colorVariables](#colorVariables)
 * [comment](#comment)
 * [decimalZero](#decimalzero)
 * [depthLevel](#depthlevel)
@@ -108,6 +109,23 @@ Option     | Description
 // Won't get rendered
 
 /*! Will get rendered, but it's OK */
+```
+
+## colorVariables
+Disallow hexidecimal colors when not used as a variable assignment.
+
+### invalid
+```less
+border: 1px solid #000;
+```
+
+### valid
+```less
+@black: #000;
+
+...
+
+border: 1px solid @black;
 ```
 
 ## decimalZero

--- a/lib/linters/README.md
+++ b/lib/linters/README.md
@@ -91,6 +91,23 @@ Option     | Description
 }
 ```
 
+## colorVariables
+Disallow hexidecimal colors when not used as a variable assignment.
+
+### invalid
+```less
+border: 1px solid #000;
+```
+
+### valid
+```less
+@black: #000;
+
+...
+
+border: 1px solid @black;
+```
+
 ## Comment
 Prefer single-line comments (`//`) over multi-line (`/* ... */`) since they're not rendered in the final CSS.
 This linter is disabled by default.
@@ -109,23 +126,6 @@ Option     | Description
 // Won't get rendered
 
 /*! Will get rendered, but it's OK */
-```
-
-## colorVariables
-Disallow hexidecimal colors when not used as a variable assignment.
-
-### invalid
-```less
-border: 1px solid #000;
-```
-
-### valid
-```less
-@black: #000;
-
-...
-
-border: 1px solid @black;
 ```
 
 ## decimalZero

--- a/lib/linters/color_variables.js
+++ b/lib/linters/color_variables.js
@@ -26,6 +26,7 @@ module.exports = {
 
         const results = [];
         ast.first.walk((child) => {
+            // Only evaluate hex colors
             if (child.type !== 'word' || !/^#/.test(child.value)) {
                 return;
             }
@@ -35,12 +36,7 @@ module.exports = {
             if (/@[a-zA-Z0-9-_]*/.test(prop)) {
                 return;
             }
-
-            // Detect hex color
             const color = child.value;
-            if (/^#\d+$/.test(color)) {
-                return;
-            }
 
             // Hex color found, add to results
             results.push({

--- a/lib/linters/color_variables.js
+++ b/lib/linters/color_variables.js
@@ -8,7 +8,7 @@ module.exports = {
     nodeTypes: ['decl'],
     message: '%s should be replaced with an existing variable.',
 
-    lint: function colorVariablesLinter(config, node) {
+    lint: function colorVariablesLinter (config, node) {
         /**
          * Just in case, since postcss will sometimes include the semicolon
          * in declaration values
@@ -21,11 +21,11 @@ module.exports = {
 
         // Parse the configuration for the style settings
         if (config.style) {
-            throw new Error(`Invalid setting value for colorVariables: ${config.style}`);
+            throw new Error(`Invalid setting value for colorVariables: ${ config.style }`);
         }
 
         const results = [];
-        ast.first.walk(child => {
+        ast.first.walk((child) => {
             if (child.type !== 'word' || !/^#/.test(child.value)) {
                 return;
             }

--- a/lib/linters/color_variables.js
+++ b/lib/linters/color_variables.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const parser = require('postcss-values-parser');
+const util = require('util');
+
+module.exports = {
+    name: 'colorVariables',
+    nodeTypes: ['decl'],
+    message: '%s should be replaced with an existing variable.',
+
+    lint: function colorVariablesLinter(config, node) {
+        /**
+         * Just in case, since postcss will sometimes include the semicolon
+         * in declaration values
+         */
+        node.value = node.value.replace(/;$/, '');
+
+        const ast = parser(node.value, {
+            loose: true
+        }).parse();
+
+        // Parse the configuration for the style settings
+        if (config.style) {
+            throw new Error(`Invalid setting value for colorVariables: ${config.style}`);
+        }
+
+        const results = [];
+        ast.first.walk(child => {
+            if (child.type !== 'word' || !/^#/.test(child.value)) {
+                return;
+            }
+
+            // If this is a variable assignment, allow hex colors
+            const prop = node.prop;
+            if (/@[a-zA-Z0-9-_]*/.test(prop)) {
+                return;
+            }
+
+            // Detect hex color
+            const color = child.value;
+            if (/^#\d+$/.test(color)) {
+                return;
+            }
+
+            // Hex color found, add to results
+            results.push({
+                column: node.source.start.column + node.prop.length + node.raws.between.length + (child.source.start.column - 1),
+                message: util.format(this.message, color)
+            });
+        });
+
+        if (results.length) {
+            return results;
+        }
+        return null;
+    }
+};

--- a/test/specs/config-loader.js
+++ b/test/specs/config-loader.js
@@ -61,7 +61,7 @@ describe('config-loader', function () {
         const expected = JSON.parse(fs.readFileSync(configPath, 'utf8'));
         const config = configLoader(configPath);
         delete config._path;
-        
+
         expect(config).to.deep.equal(expected);
     });
 

--- a/test/specs/config-loader.js
+++ b/test/specs/config-loader.js
@@ -25,6 +25,7 @@ describe('config-loader', function () {
         };
 
         const result = configLoader(config);
+        delete result._path;
 
         expect(result).to.deep.equal(expected);
     });
@@ -41,6 +42,7 @@ describe('config-loader', function () {
         fs.writeFileSync(filePath, JSON.stringify(expected));
 
         const result = configLoader();
+        delete result._path;
 
         expect(result).to.deep.equal(expected);
 
@@ -58,7 +60,8 @@ describe('config-loader', function () {
         const configPath = path.join(path.dirname(__dirname), '/data/config/config.json');
         const expected = JSON.parse(fs.readFileSync(configPath, 'utf8'));
         const config = configLoader(configPath);
-
+        delete config._path;
+        
         expect(config).to.deep.equal(expected);
     });
 
@@ -74,6 +77,7 @@ describe('config-loader', function () {
         fs.writeFileSync(configPath, JSON.stringify(expected));
 
         const result = configLoader(__dirname);
+        delete result._path;
 
         expect(result).to.deep.equal(expected);
 

--- a/test/specs/linter.js
+++ b/test/specs/linter.js
@@ -454,6 +454,33 @@ describe('linter', function () {
             expect(result).to.deep.equal(expected);
         });
 
+        it('should load a custom linter (as require path relative to .lesshintrc)', function () {
+            const source = '// boo!\n';
+            const testPath = path.resolve(process.cwd(), 'test.less');
+            const config = {
+                _path: '../test/.lesshintrc',
+                linters: ['plugins/sampleLinter'],
+                sample: true
+            };
+
+            const expected = [{
+                column: 1,
+                file: 'test.less',
+                fullPath: testPath,
+                line: 1,
+                linter: 'sample',
+                message: 'Sample error.',
+                position: 0,
+                severity: 'warning',
+                source: source.trim()
+            }];
+
+            const linter = new Linter(source, testPath, config);
+            const result = linter.lint();
+
+            expect(result).to.deep.equal(expected);
+        });
+
         it('should load a custom linter (as a passed linter)', function () {
             const source = '// boo!\n';
             const testPath = path.resolve(process.cwd(), 'test.less');

--- a/test/specs/linters/color_variables.js
+++ b/test/specs/linters/color_variables.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const expect = require('chai').expect;
+const spec = require('../util.js').setup();
+
+describe('lesshint', function () {
+    describe('#colorVariables()', function () {
+        it('should have the proper node types', function () {
+            const source = 'color: #ABC;';
+
+            return spec.parse(source, function (ast) {
+                expect(spec.linter.nodeTypes).to.include(ast.root.first.type);
+            });
+        });
+
+        it('should not allow hex values', function () {
+            const source = 'color: #ABC;';
+            const expected = [{
+                column: 8,
+                message: '#ABC should be replaced with an existing variable.'
+            }];
+
+            return spec.parse(source, function (ast) {
+                const result = spec.linter.lint({}, ast.root.first);
+
+                expect(result).to.deep.equal(expected);
+            });
+        });
+
+        it('should allow hex values when assigned to a variable', function () {
+            const source = '@myvariable: #ABC;';
+            const expected = null;
+
+            return spec.parse(source, function (ast) {
+                const result = spec.linter.lint({}, ast.root.first);
+
+                expect(result).to.deep.equal(expected);
+            });
+        });
+
+        it('should should find hex values in multi part declarations', function () {
+            const source = 'border: 1px solid #ABC;';
+            const expected = [{
+                column: 19,
+                message: '#ABC should be replaced with an existing variable.'
+            }];
+
+            return spec.parse(source, function (ast) {
+                const result = spec.linter.lint({}, ast.root.first);
+
+                expect(result).to.deep.equal(expected);
+            });
+        });
+
+        it('should throw on invalid "style" value', function () {
+            const source = 'color: #aabbcc;';
+            const options = {
+                style: 'invalid'
+            };
+
+            return spec.parse(source, function (ast) {
+                const lint = spec.linter.lint.bind(null, options, ast.root.first);
+
+                expect(lint).to.throw(Error);
+            });
+        });
+    });
+});


### PR DESCRIPTION
<!--
If you're submitting a PR for a new feature, please open an issue about it first so we can discuss it.
If you're submitting a PR for something else, for example a documentation fix, go right ahead!
-->

**Which issue, if any, does this resolve?**

Resolves this issue: https://github.com/lesshint/lesshint/issues/372

**Is there anything in this PR that needs extra explaining or should something specific be focused on?**
The main idea here is that when we parse the config file, we store the path to that config file as _path, then we can use that when we look for custom linters to support custom linter paths that are relative to the .lesshintrc file.
