### PR TITLE
If custom linter is not found by absolute url or relative to cwd, check relative to .lesshintrc

### DIFF
--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -15,7 +15,7 @@ const loadConfig = function (path) {
     }
 
     data = JSON.parse(data);
-    data._path = path;
+    data.configPath = path;
     return data;
 };
 

--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -14,7 +14,9 @@ const loadConfig = function (path) {
         data = data.slice(1);
     }
 
-    return JSON.parse(data);
+    data = JSON.parse(data);
+    data._path = path;
+    return data;
 };
 
 module.exports = function (path) {

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -260,11 +260,15 @@ class Linter {
             }
 
             let linterPath;
-
             try {
-                linterPath = require.resolve(path.join(process.cwd(), linter));
+                try {
+                    linterPath = require.resolve(path.join(process.cwd(), linter));
+                } catch (e) {
+                    linterPath = require.resolve(linter);
+                }
             } catch (e) {
-                linterPath = require.resolve(linter);
+                const pathBasedOnConfig = this.options._path.replace('.lesshintrc', linter);
+                linterPath = require.resolve(pathBasedOnConfig);
             }
 
             return require(linterPath);

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -261,14 +261,14 @@ class Linter {
 
             let linterPath;
             try {
-                try {
-                    linterPath = require.resolve(path.join(process.cwd(), linter));
-                } catch (e) {
-                    linterPath = require.resolve(linter);
-                }
+                linterPath = require.resolve(path.join(process.cwd(), linter));
             } catch (e) {
-                const pathBasedOnConfig = this.options._path.replace('.lesshintrc', linter);
-                linterPath = require.resolve(pathBasedOnConfig);
+                try {
+                    linterPath = require.resolve(linter);
+                } catch (e) {
+                    const pathBasedOnConfig = this.options._path.replace('.lesshintrc', linter);
+                    linterPath = require.resolve(pathBasedOnConfig);
+                }
             }
 
             return require(linterPath);

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -266,7 +266,7 @@ class Linter {
                 try {
                     linterPath = require.resolve(linter);
                 } catch (e) {
-                    const pathBasedOnConfig = this.options._path.replace('.lesshintrc', linter);
+                    const pathBasedOnConfig = this.options.configPath.replace('.lesshintrc', linter);
                     linterPath = require.resolve(pathBasedOnConfig);
                 }
             }

--- a/test/specs/config-loader.js
+++ b/test/specs/config-loader.js
@@ -25,7 +25,7 @@ describe('config-loader', function () {
         };
 
         const result = configLoader(config);
-        delete result._path;
+        delete result.configPath;
 
         expect(result).to.deep.equal(expected);
     });
@@ -42,7 +42,7 @@ describe('config-loader', function () {
         fs.writeFileSync(filePath, JSON.stringify(expected));
 
         const result = configLoader();
-        delete result._path;
+        delete result.configPath;
 
         expect(result).to.deep.equal(expected);
 
@@ -60,7 +60,7 @@ describe('config-loader', function () {
         const configPath = path.join(path.dirname(__dirname), '/data/config/config.json');
         const expected = JSON.parse(fs.readFileSync(configPath, 'utf8'));
         const config = configLoader(configPath);
-        delete config._path;
+        delete config.configPath;
 
         expect(config).to.deep.equal(expected);
     });
@@ -77,7 +77,7 @@ describe('config-loader', function () {
         fs.writeFileSync(configPath, JSON.stringify(expected));
 
         const result = configLoader(__dirname);
-        delete result._path;
+        delete result.configPath;
 
         expect(result).to.deep.equal(expected);
 

--- a/test/specs/config-loader.js
+++ b/test/specs/config-loader.js
@@ -61,7 +61,7 @@ describe('config-loader', function () {
         const expected = JSON.parse(fs.readFileSync(configPath, 'utf8'));
         const config = configLoader(configPath);
         delete config._path;
-        
+
         expect(config).to.deep.equal(expected);
     });
 

--- a/test/specs/config-loader.js
+++ b/test/specs/config-loader.js
@@ -25,6 +25,7 @@ describe('config-loader', function () {
         };
 
         const result = configLoader(config);
+        delete result._path;
 
         expect(result).to.deep.equal(expected);
     });
@@ -41,6 +42,7 @@ describe('config-loader', function () {
         fs.writeFileSync(filePath, JSON.stringify(expected));
 
         const result = configLoader();
+        delete result._path;
 
         expect(result).to.deep.equal(expected);
 
@@ -58,7 +60,8 @@ describe('config-loader', function () {
         const configPath = path.join(path.dirname(__dirname), '/data/config/config.json');
         const expected = JSON.parse(fs.readFileSync(configPath, 'utf8'));
         const config = configLoader(configPath);
-
+        delete config._path;
+        
         expect(config).to.deep.equal(expected);
     });
 
@@ -74,6 +77,7 @@ describe('config-loader', function () {
         fs.writeFileSync(configPath, JSON.stringify(expected));
 
         const result = configLoader(__dirname);
+        delete result._path;
 
         expect(result).to.deep.equal(expected);
 

--- a/test/specs/linter.js
+++ b/test/specs/linter.js
@@ -458,7 +458,7 @@ describe('linter', function () {
             const source = '// boo!\n';
             const testPath = path.resolve(process.cwd(), 'test.less');
             const config = {
-                _path: '../test/.lesshintrc',
+                configPath: '../test/.lesshintrc',
                 linters: ['plugins/sampleLinter'],
                 sample: true
             };

--- a/test/specs/linter.js
+++ b/test/specs/linter.js
@@ -454,6 +454,33 @@ describe('linter', function () {
             expect(result).to.deep.equal(expected);
         });
 
+        it('should load a custom linter (as require path relative to .lesshintrc)', function () {
+            const source = '// boo!\n';
+            const testPath = path.resolve(process.cwd(), 'test.less');
+            const config = {
+                _path: '../test/.lesshintrc',
+                linters: ['plugins/sampleLinter'],
+                sample: true
+            };
+
+            const expected = [{
+                column: 1,
+                file: 'test.less',
+                fullPath: testPath,
+                line: 1,
+                linter: 'sample',
+                message: 'Sample error.',
+                position: 0,
+                severity: 'warning',
+                source: source.trim()
+            }];
+
+            const linter = new Linter(source, testPath, config);
+            const result = linter.lint();
+
+            expect(result).to.deep.equal(expected);
+        });
+
         it('should load a custom linter (as a passed linter)', function () {
             const source = '// boo!\n';
             const testPath = path.resolve(process.cwd(), 'test.less');


### PR DESCRIPTION
<!--
If you're submitting a PR for a new feature, please open an issue about it first so we can discuss it.
If you're submitting a PR for something else, for example a documentation fix, go right ahead!
-->

**Which issue, if any, does this resolve?**
#372 

**Is there anything in this PR that needs extra explaining or should something specific be focused on?**
Basic gist is that I am adding _path to the config data that contains the path to the .lesshintrc file. This allows me to find custom linters relative to .lesshintrc.
