### PR TITLE
Add Lesshint.getFiles() method

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "commander": "^2.8.0",
+    "globby": "^6.1.0",
     "lodash.merge": "^4.0.1",
     "lodash.sortby": "^4.0.1",
     "minimatch": "^3.0.2",


### PR DESCRIPTION
This is a more general method which works on globs and handles everything instead of having separate methods.

<!--
If you're submitting a PR for a new feature, please open an issue about it first so we can discuss it.
If you're submitting a PR for something else, for example a documentation fix, go right ahead!
-->

**Which issue, if any, does this resolve?**
Point 4 of #357.

**Is there anything in this PR that needs extra explaining or should something specific be focused on?**
I'm thinking we should deprecate these methods in favor of `Lesshint.getFiles()`:
* `Lesshint.checkDirectory()`
* `Lesshint.checkFile()`
* `Lesshint.checkPath()`

I also think we should deprecate the `fileExtensions` and `excludedFiles` options and let them be handled by glob patterns instead. What do other people think?

Is it enough to add docs about things being deprecated or should we use something like [`util.deprecate`](https://nodejs.org/api/util.html#util_util_deprecate_function_string)?