### PR TITLE
Add Lesshint.checkFiles() method

### DIFF
--- a/docs/developer-guide/api/lesshint.md
+++ b/docs/developer-guide/api/lesshint.md
@@ -38,6 +38,19 @@ result.then((results) => {
 });
 ```
 
+## `Lesshint.checkFiles(pattern)`
+Check a glob pattern asynchronously. Will not check `fileExtensions` and `excludedFiles` options.
+
+A `Promise` will be returned.
+
+```js
+const result = lesshint.checkFiles('/path/**/*.less');
+
+result.then((results) => {
+
+});
+```
+
 ## `Lesshint.checkPath(checkPath)`
 Check a path asynchronously. If a file is passed it will check that, if a directory is passed it will check that recursively. Will respect `fileExtensions` and `excludedFiles` options.
 

--- a/lib/lesshint.js
+++ b/lib/lesshint.js
@@ -5,6 +5,7 @@ const configLoader = require('./config-loader');
 const minimatch = require('minimatch');
 const merge = require('lodash.merge');
 const Linter = require('./linter');
+const globby = require('globby');
 const path = require('path');
 const fs = require('fs');
 
@@ -48,17 +49,7 @@ class Lesshint {
                     });
                 });
 
-                Promise.all(files)
-                    .then((results) => {
-                        results = [].concat.apply([], results);
-
-                        resolve(results);
-                    })
-                    .catch((error) => {
-                        error = new LesshintError(error, error.path);
-
-                        reject(error);
-                    });
+                this.formatResults(files, resolve, reject);
             });
         });
     }
@@ -76,6 +67,24 @@ class Lesshint {
                     reject(e);
                 }
             });
+        });
+    }
+
+    checkFiles (pattern) {
+        return new Promise((resolve, reject) => {
+            globby(pattern)
+                .then((files) => {
+                    files = files.map((file) => {
+                        return this.checkFile(file);
+                    });
+
+                    this.formatResults(files, resolve, reject);
+                })
+                .catch((error) => {
+                    error = new LesshintError(error, error.path);
+
+                    reject(error);
+                });
         });
     }
 
@@ -149,6 +158,20 @@ class Lesshint {
         });
 
         return fileExtensions.indexOf(path.extname(file)) !== -1;
+    }
+
+    formatResults (files, resolve, reject) {
+        Promise.all(files)
+            .then((results) => {
+                results = [].concat.apply([], results);
+
+                resolve(results);
+            })
+            .catch((error) => {
+                error = new LesshintError(error, error.path);
+
+                reject(error);
+            });
     }
 
     isExcluded (checkPath) {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "commander": "^2.8.0",
+    "globby": "^6.1.0",
     "lodash.merge": "^4.0.1",
     "lodash.sortby": "^4.0.1",
     "minimatch": "^3.0.2",

--- a/test/specs/lesshint.js
+++ b/test/specs/lesshint.js
@@ -160,6 +160,20 @@ describe('lesshint', function () {
         });
     });
 
+    describe('checkFiles', function () {
+        const glob = path.join(path.dirname(__dirname), '/data/files/**/*.less');
+
+        it('should check all files matched by glob', function () {
+            const lesshint = new Lesshint();
+
+            lesshint.configure();
+
+            return lesshint.checkFiles(glob).then(function (result) {
+                expect(result).to.have.length(2);
+            });
+        });
+    });
+
     describe('checkPath', function () {
         it('should check all files and directories on all levels of a path', function () {
             const lesshint = new Lesshint();


### PR DESCRIPTION
This is a more general method which works on globs and handles everything instead of having separate methods.

<!--
If you're submitting a PR for a new feature, please open an issue about it first so we can discuss it.
If you're submitting a PR for something else, for example a documentation fix, go right ahead!
-->

**Which issue, if any, does this resolve?**
Point 4 of #357.

**Is there anything in this PR that needs extra explaining or should something specific be focused on?**
I'm thinking we should deprecate these methods in favor of `Lesshint.checkFiles()`:
* `Lesshint.checkDirectory()`
* `Lesshint.checkFile()`
* `Lesshint.checkPath()`

I also think we should deprecate the `fileExtensions` and `excludedFiles` options and let them be handled by glob patterns instead. What do other people think?

Is it enough to add docs about things being deprecated or should we use something like [`util.deprecate`](https://nodejs.org/api/util.html#util_util_deprecate_function_string)?