### PR TITLE
Warnings gives exit code 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,8 @@ Depending on the linter results and options supplied, the exit status code retur
 
 Exit status code   | Description
 -------------------|----------------------------------------------
-`0`                | Everything is alright, no linting errors found.
-`1`                | One or more linting errors with a severity of `warning` was found.
-`2`                | One or more linting errors with a severity of `error` was found.
+`0`                | Everything is alright or only linting errors with a severity of `warning` were found.
+`1`                | One or more linting errors with a severity of `error` were found. Also when `--max-warnings` flag is set and the number of linting errors with a severity of `warning` found is greater than the given value.
 `66`               | No files to lint were supplied.
 `70`               | An unknown error occurred within `lesshint`, possibly a bug. [Please file an issue!](https://github.com/lesshint/lesshint/issues/new)
 `78`               | Something is wrong with the config file, most likely invalid JSON.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Available Flags         | Description
 `-l`/`--linters`      | Paths to custom linters to add to the built-in list. See "Linters" below for more information.
 `-r`/`--reporter`     | The reporter to use. See "Reporters" below for more information.
 `-V`/`--version`      | Show the version.
-`-x`/`--max-warnings` | Number of warnings to allow before exiting with a non-zero code.
+`-x`/`--max-warnings` | Number of warnings to allow before exiting with a non-zero code. Skip it to always exit with zero code.
 
 ### Exit status codes
 Depending on the linter results and options supplied, the exit status code returned by the CLI will differ.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Available Flags         | Description
 `-l`/`--linters`      | Paths to custom linters to add to the built-in list. See "Linters" below for more information.
 `-r`/`--reporter`     | The reporter to use. See "Reporters" below for more information.
 `-V`/`--version`      | Show the version.
-`-x`/`--max-warnings` | Number of warnings to allow before exiting with a non-zero code. Skip it to always exit with zero code.
+`-x`/`--max-warnings` | Number of warnings to allow before exiting with a non-zero code. Omit it to always exit with zero code.
 
 ### Exit status codes
 Depending on the linter results and options supplied, the exit status code returned by the CLI will differ.
@@ -51,7 +51,7 @@ Depending on the linter results and options supplied, the exit status code retur
 Exit status code   | Description
 -------------------|----------------------------------------------
 `0`                | Everything is alright or only linting errors with a severity of `warning` were found.
-`1`                | One or more linting errors with a severity of `error` were found. Also when `--max-warnings` flag is set and the number of linting errors with a severity of `warning` found is greater than the given value.
+`1`                | One or more linting errors with a severity of `error` were found. Or when `--max-warnings` flag is set and the number of linting errors with a severity of `warning` found is greater than the given value.
 `66`               | No files to lint were supplied.
 `70`               | An unknown error occurred within `lesshint`, possibly a bug. [Please file an issue!](https://github.com/lesshint/lesshint/issues/new)
 `78`               | Something is wrong with the config file, most likely invalid JSON.

--- a/bin/lesshint
+++ b/bin/lesshint
@@ -18,7 +18,7 @@ program
     .option('-e, --exclude [pattern]', 'path pattern to exclude')
     .option('-l, --linters [linters]', 'paths to custom linters')
     .option('-r, --reporter [reporter]', 'reporter to use (<PATH>|stylish), defaults to "stylish"')
-    .option('-x, --max-warnings [int]', 'Number of warnings to trigger nonzero exit code, defaults to 0')
+    .option('-x, --max-warnings [int]', 'Number of warnings to trigger nonzero exit code, defaults to unlimited')
     .parse(process.argv);
 
 const output = function (result) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -88,13 +88,11 @@ class Runner {
 
                 let maxWarnings;
 
-                if (isFinite(this.options.maxWarnings)) {
+                if (this.options.maxWarnings) {
                     maxWarnings = parseInt(this.options.maxWarnings, 10) || 0;
-                } else {
-                    maxWarnings = new Boolean(this.options.maxWarnings) ? 0 : -1;
                 }
 
-                if (maxWarnings === -1) {
+                if (typeof maxWarnings === 'undefined') {
                     return resolve({
                         status: EXIT_CODES.OK
                     });

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -6,8 +6,7 @@ const Lesshint = require('./lesshint');
 
 const EXIT_CODES = {
     OK: 0,
-    WARNING: 1,
-    ERROR: 2,
+    ERROR: 1,
     NOINPUT: 66,
     SOFTWARE: 70,
     CONFIG: 78
@@ -105,7 +104,7 @@ class Runner {
                 if (warnings > maxWarnings) {
                     return reject(new RunnerError(
                         '',
-                        EXIT_CODES.WARNING
+                        EXIT_CODES.ERROR
                     ));
                 }
 

--- a/test/specs/bin/lesshint.js
+++ b/test/specs/bin/lesshint.js
@@ -34,11 +34,20 @@ describe('bin/lesshint', () => {
         return assertCode(child, 0);
     });
 
-    it('should exit with 1 when errors are found', function () {
+
+    it('should exit with 0 when warnings are found', function () {
         const filePath = path.resolve(__dirname, '../../data/files/file.less');
         const child = runLesshint([filePath]);
 
-        return assertCode(child, 1);
+        return assertCode(child, 0);
+    });
+
+    it('should exit with 2 when errors are found', function () {
+        const configPath = path.resolve(__dirname, '../../data/config/severity-error.json');
+        const filePath = path.resolve(__dirname, '../../data/files/file.less');
+        const child = runLesshint([`--config=${ configPath }`, filePath]);
+
+        return assertCode(child, 2);
     });
 
     it('should exit with 78 when passed an invalid config file', function () {

--- a/test/specs/bin/lesshint.js
+++ b/test/specs/bin/lesshint.js
@@ -42,12 +42,12 @@ describe('bin/lesshint', () => {
         return assertCode(child, 0);
     });
 
-    it('should exit with 2 when errors are found', function () {
+    it('should exit with 1 when errors are found', function () {
         const configPath = path.resolve(__dirname, '../../data/config/severity-error.json');
         const filePath = path.resolve(__dirname, '../../data/files/file.less');
         const child = runLesshint([`--config=${ configPath }`, filePath]);
 
-        return assertCode(child, 2);
+        return assertCode(child, 1);
     });
 
     it('should exit with 78 when passed an invalid config file', function () {

--- a/test/specs/cli.js
+++ b/test/specs/cli.js
@@ -23,14 +23,14 @@ describe('cli', function () {
         }
     });
 
-    it('should exit with a non-zero status code when lint errors were found', function () {
+    it('should exit with a zero status code when lint errors were found', function () {
         const result = cli({
             args: [path.dirname(__dirname) + '/data/files/file.less'],
             config: path.resolve(process.cwd() + '/lib/config/defaults.json')
         });
 
-        return result.catch(function (result) {
-            expect(result.status).to.equal(1);
+        return result.then(function (result) {
+            expect(result.status).to.equal(0);
         });
     });
 
@@ -150,8 +150,8 @@ describe('cli', function () {
             linters: ['../test/plugins/sampleLinter']
         });
 
-        return result.catch(function (result) {
-            expect(result.status).to.equal(1);
+        return result.then(function (result) {
+            expect(result.status).to.equal(0);
         });
     });
 
@@ -161,8 +161,8 @@ describe('cli', function () {
             config: path.resolve(process.cwd() + '/test/data/config/linters.json')
         });
 
-        return result.catch(function (result) {
-            expect(result.status).to.equal(1);
+        return result.then(function (result) {
+            expect(result.status).to.equal(0);
         });
     });
 
@@ -173,8 +173,8 @@ describe('cli', function () {
             linters: ['../test/plugins/otherSampleLinter']
         });
 
-        return result.catch(function (result) {
-            expect(result.status).to.equal(1);
+        return result.then(function (result) {
+            expect(result.status).to.equal(0);
         });
     });
 

--- a/test/specs/cli.js
+++ b/test/specs/cli.js
@@ -255,7 +255,7 @@ describe('cli', function () {
         });
 
         return result.catch(function (result) {
-            expect(result.status).to.equal(2);
+            expect(result.status).to.equal(1);
         });
     });
 });

--- a/test/specs/cli.js
+++ b/test/specs/cli.js
@@ -82,21 +82,6 @@ describe('cli', function () {
                 path.dirname(__dirname) + '/data/files/file.less',
             ],
             config: path.resolve(process.cwd() + '/lib/config/defaults.json'),
-            maxWarnings: '999',
-        });
-
-        return result.then(function (result) {
-            expect(result.status).to.equal(0);
-        });
-    });
-
-    it('should exit with a zero status code with `--max-warnings -1` even if lint has warings', function () {
-        const result = cli({
-            args: [
-                path.dirname(__dirname) + '/data/files/file.less',
-            ],
-            config: path.resolve(process.cwd() + '/lib/config/defaults.json'),
-            maxWarnings: '-1',
         });
 
         return result.then(function (result) {


### PR DESCRIPTION
<!--
If you're submitting a PR for a new feature, please open an issue about it first so we can discuss it.
If you're submitting a PR for something else, for example a documentation fix, go right ahead!
-->

**Changes proposed in this PR:** 
Changed the approach of exit codes to:
- Linting errors with a severity of `warning` gives exit code `0`
  - Unless `--max-warnings` flag is set and the number of linting errors with a severity of `warning` is greater than the given value. Then it gives exit code `1`
- Linting errors with a severity of `error` gives exit code `1`

**Which issue, if any, does this resolve?** 
Will close #394. 

**Is there anything in this PR that needs extra explaining or should something specific be focused on?** 
The whole logic was already discussed in corresponding GitHub issue (#394).

@jwilsson please take a look.
