### PR TITLE
Add a Lesshint.checkFiles() method

### DIFF
--- a/docs/developer-guide/api/lesshint.md
+++ b/docs/developer-guide/api/lesshint.md
@@ -13,6 +13,8 @@ lesshint.configure();
 ```
 
 ## `Lesshint.checkDirectory(checkPath)`
+**Deprecated. Use Lesshint.checkFiles() instead.**
+
 Check a directory recursively. Will respect `fileExtensions` and `excludedFiles` options.
 
 A `Promise` will be returned.
@@ -26,6 +28,8 @@ result.then((results) => {
 ```
 
 ## `Lesshint.checkFile(checkPath)`
+**Deprecated. Use Lesshint.checkFiles() instead.**
+
 Check a single file asynchronously. Will not check `fileExtensions` and `excludedFiles` options.
 
 A `Promise` will be returned.
@@ -38,7 +42,22 @@ result.then((results) => {
 });
 ```
 
+## `Lesshint.checkFiles(patterns)`
+Check a string or an array of glob patterns asynchronously. Will respect `fileExtensions` and `excludedFiles` options.
+
+A `Promise` will be returned.
+
+```js
+const result = lesshint.checkFiles('/path/**/*.less');
+
+result.then((results) => {
+
+});
+```
+
 ## `Lesshint.checkPath(checkPath)`
+**Deprecated. Use Lesshint.checkFiles() instead.**
+
 Check a path asynchronously. If a file is passed it will check that, if a directory is passed it will check that recursively. Will respect `fileExtensions` and `excludedFiles` options.
 
 A `Promise` will be returned.

--- a/lib/lesshint.js
+++ b/lib/lesshint.js
@@ -5,6 +5,7 @@ const configLoader = require('./config-loader');
 const minimatch = require('minimatch');
 const merge = require('lodash.merge');
 const Linter = require('./linter');
+const globby = require('globby');
 const path = require('path');
 const fs = require('fs');
 
@@ -48,17 +49,7 @@ class Lesshint {
                     });
                 });
 
-                Promise.all(files)
-                    .then((results) => {
-                        results = [].concat.apply([], results);
-
-                        resolve(results);
-                    })
-                    .catch((error) => {
-                        error = new LesshintError(error, error.path);
-
-                        reject(error);
-                    });
+                this.formatResults(files, resolve, reject);
             });
         });
     }
@@ -76,6 +67,31 @@ class Lesshint {
                     reject(e);
                 }
             });
+        });
+    }
+
+    checkFiles (patterns) {
+        return new Promise((resolve, reject) => {
+            const ignorePatterns = this.config.excludedFiles.map((pattern) => {
+                return `!${ pattern }`;
+            });
+
+            patterns = patterns.concat(ignorePatterns);
+
+            globby(patterns)
+                .then((files) => {
+                    files = files.filter(this.hasAllowedExtension, this);
+                    files = files.map((file) => {
+                        return this.checkFile(file);
+                    });
+
+                    this.formatResults(files, resolve, reject);
+                })
+                .catch((error) => {
+                    error = new LesshintError(error, error.path);
+
+                    reject(error);
+                });
         });
     }
 
@@ -151,6 +167,20 @@ class Lesshint {
         });
 
         return fileExtensions.indexOf(path.extname(file)) !== -1;
+    }
+
+    formatResults (files, resolve, reject) {
+        Promise.all(files)
+            .then((results) => {
+                results = [].concat.apply([], results);
+
+                resolve(results);
+            })
+            .catch((error) => {
+                error = new LesshintError(error, error.path);
+
+                reject(error);
+            });
     }
 
     isExcluded (checkPath) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -53,7 +53,7 @@ class Runner {
 
             lesshint.configure(config);
 
-            const promises = this.options.args.map(lesshint.checkPath, lesshint);
+            const promises = this.options.args.map(lesshint.checkFiles, lesshint);
             const reporter = lesshint.getReporter(this.options.reporter);
 
             if (!reporter) {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "commander": "^2.8.0",
+    "globby": "^7.0.0",
     "lodash.merge": "^4.0.1",
     "lodash.sortby": "^4.0.1",
     "minimatch": "^3.0.2",

--- a/test/specs/lesshint.js
+++ b/test/specs/lesshint.js
@@ -160,6 +160,48 @@ describe('lesshint', function () {
         });
     });
 
+    describe('checkFiles', function () {
+        const glob = path.join(path.dirname(__dirname), '/data/files/**/*.less');
+
+        it('should check all files matched by glob', function () {
+            const lesshint = new Lesshint();
+
+            lesshint.configure();
+
+            return lesshint.checkFiles(glob).then(function (result) {
+                expect(result).to.have.length(2);
+            });
+        });
+
+        it('should ignore excluded folders', function () {
+            const testPath = path.join(path.dirname(__dirname), '/data/excluded-files');
+            const lesshint = new Lesshint();
+            const config = {
+                excludedFiles: ['**/excluded-files']
+            };
+
+            lesshint.configure(config);
+
+            return lesshint.checkFiles(testPath).then(function (result) {
+                expect(result).to.have.length(0);
+            });
+        });
+
+        it('should only check files with the correct extension', function () {
+            const testPath = path.join(path.dirname(__dirname), '/data/excluded-files');
+            const lesshint = new Lesshint();
+            const config = {
+                fileExtensions: ['.less']
+            };
+
+            lesshint.configure(config);
+
+            return lesshint.checkFiles(testPath).then(function (result) {
+                expect(result).to.have.length(2);
+            });
+        });
+    });
+
     describe('checkPath', function () {
         it('should check all files and directories on all levels of a path', function () {
             const lesshint = new Lesshint();


### PR DESCRIPTION
This is a more general method which works on globs and handles everything instead of having separate methods. It'll check `fileExtensions` and `excludedFiles` options for backwards compatibility but that can just be specified in the glob pattern.

With `globby@7` this should work exactly like `Lesshint.checkPath()` does today with regards to walking directories (that's the point of this new method at least).

<!--
If you're submitting a PR for a new feature, please open an issue about it first so we can discuss it.
If you're submitting a PR for something else, for example a documentation fix, go right ahead!
-->

**Which issue, if any, does this resolve?**
Point 4 of #357.

**Is there anything in this PR that needs extra explaining or should something specific be focused on?**
I'm thinking we deprecate these methods in favor of `Lesshint.checkFiles()`:

* `Lesshint.checkDirectory()`
* `Lesshint.checkFile()`
* `Lesshint.checkPath()`

They're only marked as deprecated in the docs and I say we remove them in the next major version. 