### PR TITLE
zeroUnit: exclude flex-grow/-shrink

### DIFF
--- a/lib/linters/zero_unit.js
+++ b/lib/linters/zero_unit.js
@@ -11,7 +11,7 @@ module.exports = {
     lint: function zeroUnitLinter (config, node) {
         // Units to check for
         const units = ['em', 'ex', 'ch', 'rem', 'vw', 'vh', 'vmin', 'vmax', 'cm', 'mm', 'in', 'pt', 'pc', 'px'];
-        let excludedProperties = ['opacity', 'z-index'];
+        let excludedProperties = ['opacity', 'z-index', 'flex-shrink', 'flex-grow'];
         let excludedUnits = [];
 
         if (config) {


### PR DESCRIPTION
these rules deal in unitless numbers; to suggest they require units is an error.
see: https://developer.mozilla.org/en-US/docs/Web/CSS/flex

would ignore `flex` too, but it has `flex-basis` as its third input, which may need a unit.

<!--
If you're submitting a PR for a new feature, please open an issue about it first so we can discuss it.
If you're submitting a PR for something else, for example a documentation fix, go right ahead!
-->

**Which issue, if any, does this resolve?**
none