### PR TITLE
Better report on ordering errors

### DIFF
--- a/lib/linters/property_ordering.js
+++ b/lib/linters/property_ordering.js
@@ -6,7 +6,7 @@ const util = require('util');
 module.exports = {
     name: 'propertyOrdering',
     nodeTypes: ['atrule', 'rule'],
-    message: 'Property ordering is not %s',
+    message: '"%s" should be before "%s"',
 
     lint: function propertyOrderingLinter (config, node) {
         let ordering;
@@ -49,16 +49,10 @@ module.exports = {
             }
 
             if (report) {
-                let mode = config.style;
-
-                if (config.style === 'alpha') {
-                    mode = 'alphabetized';
-                }
-
                 results.push({
                     column: child.source.start.column,
                     line: child.source.start.line,
-                    message: util.format(this.message, mode)
+                    message: util.format(this.message, currentProperty, previousProp)
                 });
             }
 

--- a/test/specs/linter.js
+++ b/test/specs/linter.js
@@ -119,7 +119,7 @@ describe('linter', function () {
                     fullPath: testPath,
                     line: 3,
                     linter: 'propertyOrdering',
-                    message: 'Property ordering is not alphabetized',
+                    message: '"color" should be before "margin-right"',
                     position: 50,
                     severity: 'warning',
                     source: 'color: red;'

--- a/test/specs/linters/property_ordering.js
+++ b/test/specs/linters/property_ordering.js
@@ -60,7 +60,7 @@ describe('lesshint', function () {
                 const expected = [{
                     column: 26,
                     line: 1,
-                    message: 'Property ordering is not alphabetized'
+                    message: '"color" should be before "padding-top"'
                 }];
 
                 return spec.parse(source, function (ast) {
@@ -112,7 +112,7 @@ describe('lesshint', function () {
                 const expected = [{
                     column: 31,
                     line: 1,
-                    message: 'Property ordering is not alphabetized'
+                    message: '"color" should be before "opacity"'
                 }];
 
                 return spec.parse(source, function (ast) {
@@ -155,7 +155,7 @@ describe('lesshint', function () {
                 const expected = [{
                     column: 37,
                     line: 1,
-                    message: 'Property ordering is not concentric',
+                    message: '"right" should be before "color"',
                 }];
 
                 return spec.parse(source, function (ast) {
@@ -207,7 +207,7 @@ describe('lesshint', function () {
                 const expected = [{
                     column: 31,
                     line: 1,
-                    message: 'Property ordering is not concentric',
+                    message: '"opacity" should be before "color"',
                 }];
 
                 return spec.parse(source, function (ast) {
@@ -222,7 +222,7 @@ describe('lesshint', function () {
                 const expected = [{
                     column: 31,
                     line: 1,
-                    message: 'Property ordering is not concentric',
+                    message: '"bar" should be before "foo"',
                 }];
 
                 return spec.parse(source, function (ast) {
@@ -237,7 +237,7 @@ describe('lesshint', function () {
                 const expected = [{
                     column: 17,
                     line: 1,
-                    message: 'Property ordering is not concentric',
+                    message: '"display" should be before "foo"',
                 }];
 
                 return spec.parse(source, function (ast) {


### PR DESCRIPTION
Following  #496 

Sorry I did not see it before but it's now really boring to only have a "not concentric" error. 

Here I show a "move it before" message, it's not perfect as you got it for every line, but it's a start. 

I will look later if we can find the correct position on first time.

(It may be better to merge this in a 5.2.1 and create a feature request for later)