### PR TITLE
Feature: Restrict import paths

### DIFF
--- a/lib/config/defaults.json
+++ b/lib/config/defaults.json
@@ -64,6 +64,10 @@
         "exclude": []
     },
 
+    "importRestrict": {
+        "enabled": false
+    },
+
     "importantRule": {
         "enabled": true
     },

--- a/lib/linters/README.md
+++ b/lib/linters/README.md
@@ -13,6 +13,7 @@
 * [hexNotation](#hexnotation)
 * [hexValidation](#hexvalidation)
 * [idSelector](#idselector)
+* [importRestrict](#importrestrict)
 * [importantRule](#importantrule)
 * [importPath](#importpath)
 * [maxCharPerLine](#maxcharperline)
@@ -333,6 +334,33 @@ Option     | Description
 .foo {
     color: red;
 }
+```
+
+## importRestrict
+Restrict imports of files with provided prefix. Restrict imports of files with provided pattern.
+
+Option               | Description
+-------------------- | ----------
+`restrictPrefix`     | Array(string[]) of import prefixes you wish to restrict usage
+`restrictPattern`    | Array(string[]) of import patterns you wish to restrict usage
+
+```js
+"importRestrict": {
+    "restrictPrefix": ["lodash"], // Restrict the usage of imports from lodash library
+    "restrictPattern": ["colors"] // Restrict the usage of imports containing "colors" in the import path
+}
+```
+
+### invalid
+```less
+@import 'lodash/foo';
+@import '../../colors/bar.less';
+```
+
+### valid
+```less
+@import 'foo';
+@import 'bar';
 ```
 
 ## importantRule

--- a/lib/linters/import_restrict.js
+++ b/lib/linters/import_restrict.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const util = require('util');
+
+/*
+ * This rule restricts @imports which are importing from paths starting with strings specified in 'restrictPrefix' rule
+ * setting and restricts the @imports which are importing from paths conatining strings specified in 'restrictPattern'
+ * rule setting.
+ */
+module.exports = {
+    name: 'importRestrict',
+    nodeTypes: ['atrule'],
+    message: {
+        prefix: 'Imported file with path prefix "%s" is restricted.',
+        pattern: 'Imported file contains "%s" which is a restricted @import path pattern.'
+    },
+
+    lint: function importRestrictLinter (config, node) {
+        if (!node.import) {
+            return;
+        }
+
+        const { filename } = node;
+        const value = filename.trim().replace(/['"]/g, '');
+
+        const results = [];
+        const { column, line } = node.positionBy({
+            word: value
+        });
+
+        if (config.restrictPrefix) {
+            config.restrictPrefix.forEach((prefix) => {
+                if (value.startsWith(prefix)) {
+                    results.push({
+                        column,
+                        line,
+                        message: util.format(this.message.prefix, prefix)
+                    });
+                }
+            });
+        }
+
+        if (config.restrictPattern) {
+            config.restrictPattern.forEach((pattern) => {
+                if (value.includes(pattern)) {
+                    results.push({
+                        column,
+                        line,
+                        message: util.format(this.message.pattern, pattern)
+                    });
+                }
+            });
+        }
+
+        if (results.length) {
+            return results;
+        }
+    }
+};

--- a/test/specs/linters/import_restrict.js
+++ b/test/specs/linters/import_restrict.js
@@ -1,0 +1,101 @@
+'use strict';
+
+const { expect } = require('chai');
+const spec = require('../util.js').setup();
+
+describe('lesshint', function () {
+    describe('#importRestrict()', function () {
+        it('should have the proper node types', function () {
+            const source = '@import "foo";';
+
+            return spec.parse(source, function (ast) {
+                expect(spec.linter.nodeTypes).to.include(ast.root.first.type);
+            });
+        });
+
+        it('should allow import path when no prefix provided', function () {
+            const source = '@import "foo";';
+            const options = {
+                restrictPrefix: [],
+            };
+
+            return spec.parse(source, function (ast) {
+                const result = spec.linter.lint(options, ast.root.first);
+
+                expect(result).to.be.undefined;
+            });
+        });
+
+        it('should allow import path when prefix is different from the one provided', function () {
+            const source = '@import "foo/bar";';
+            const options = {
+                restrictPrefix: ['bar'],
+            };
+
+            return spec.parse(source, function (ast) {
+                const result = spec.linter.lint(options, ast.root.first);
+
+                expect(result).to.be.undefined;
+            });
+        });
+
+        it('should not allow import path with prefix', function () {
+            const source = '@import "foo";';
+            const options = {
+                restrictPrefix: ['foo'],
+            };
+            const expected = [{
+                column: 10,
+                line: 1,
+                message: 'Imported file with path prefix "foo" is restricted.'
+            }];
+
+            return spec.parse(source, function (ast) {
+                const result = spec.linter.lint(options, ast.root.first);
+
+                expect(result).to.deep.equal(expected);
+            });
+        });
+
+        it('should allow import path when path includes a different string from the one provided', function () {
+            const source = '@import "bar";';
+            const options = {
+                restrictPattern: ['foo'],
+            };
+
+            return spec.parse(source, function (ast) {
+                const result = spec.linter.lint(options, ast.root.first);
+
+                expect(result).to.be.undefined;
+            });
+        });
+
+        it('should not allow import path when path includes a string provided as restricted pattern', function () {
+            const source = '@import "some/random/bar/styles.less";';
+            const options = {
+                restrictPattern: ['random/bar'],
+            };
+            const expected = [{
+                column: 10,
+                line: 1,
+                message: 'Imported file contains "random/bar" which is a restricted @import path pattern.'
+            }];
+
+            return spec.parse(source, function (ast) {
+                const result = spec.linter.lint(options, ast.root.first);
+
+                expect(result).to.deep.equal(expected);
+            });
+        });
+
+        it('should ignore other at-rules', function () {
+            const source = '@charset "utf-8";';
+
+            return spec.parse(source, function (ast) {
+                const result = spec.linter.lint({}, ast.root.first);
+
+                expect(result).to.be.undefined;
+            });
+        });
+    });
+});


### PR DESCRIPTION
Adds a linter that checks `@import` paths and errors out based on the restricted prefixes, patterns provided to the linter. 

We use this custom linter in our multi-app angular project, could be a part of the `lesshint` and help others as well.