### PR TITLE
fix(color_variables): valueOf undefined

### DIFF
--- a/lib/linters/color_variables.js
+++ b/lib/linters/color_variables.js
@@ -10,6 +10,11 @@ module.exports = {
     message: '%s should be replaced with an existing variable.',
 
     lint: function colorVariablesLinter (config, node) {
+        // Nothing to check, bail
+        if (!node.value) {
+            return;
+        }
+
         const ast = parseValue(node.value);
         const results = [];
 

--- a/test/specs/linters/color_variables.js
+++ b/test/specs/linters/color_variables.js
@@ -39,7 +39,7 @@ describe('lesshint', function () {
             });
         });
 
-        it('should should find hex values in multi part declarations', function () {
+        it('should find hex values in multi part declarations', function () {
             const source = 'border: 1px solid #ABC;';
             const expected = [{
                 column: 19,
@@ -51,6 +51,16 @@ describe('lesshint', function () {
                 const result = spec.linter.lint({}, ast.root.first);
 
                 expect(result).to.deep.equal(expected);
+            });
+        });
+
+        it('should not check nodes without values', function () {
+            const source = '.foo { @bar() }';
+
+            return spec.parse(source, function (ast) {
+                const result = spec.linter.lint({}, ast.root.first);
+
+                expect(result).to.be.undefined;
             });
         });
     });


### PR DESCRIPTION
<!--
If you're submitting a PR for a new feature, please open an issue about it first so we can discuss it.
If you're submitting a PR for something else, for example a documentation fix, go right ahead!
-->

**Which issue, if any, does this resolve?**
`colorVariables` linter was throwing an error for undefined values 
``` TypeError: Cannot read property 'valueOf' of undefined ```
**Is there anything in this PR that needs extra explaining or should something specific be focused on?**
